### PR TITLE
Migrate to Sessions API

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -22,11 +22,11 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     /** @var array Array of locales */
     public $locale;
 
-    /** @var bool Whether or not logging is enabled */
-    public static $log_enabled = false;
+    /** @var boolean Whether or not logging is enabled */
+    public static $log_enabled;
 
     /** @var WC_Logger Logger instance */
-    public static $log = false;
+    public static $log;
 
     /**
      * Constructor for the gateway.
@@ -61,8 +61,8 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             $this->enabled = 'no';
             WC_Gateway_Komoju::log('is not valid for use. No IPN set.');
         } else {
-            include_once 'includes/class-wc-gateway-komoju-ipn-handler.php';
-            new WC_Gateway_Komoju_IPN_Handler($this->webhookSecretToken, $this->secretKey, $this->invoice_prefix);
+            include_once( 'includes/class-wc-gateway-komoju-ipn-handler.php' );
+            new WC_Gateway_Komoju_IPN_Handler( $this, $this->webhookSecretToken, $this->secretKey, $this->invoice_prefix );
         }
     }
 
@@ -136,7 +136,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
           'payment_data' => [
             'amount' => $order->get_total(),
             'currency' => get_woocommerce_currency(),
-            'external_order_num' => strval( $order_id )
+            'external_order_num' => $this->external_order_num( $order )
           ],
         ]);
 
@@ -154,6 +154,15 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     public function payment_fields()
     {
         $this->komoju_method_form();
+    }
+
+    /**
+     * set KOMOJU side reference for order
+     * @param WC_Order $order
+     */
+    private function external_order_num( $order ) {
+      $suffix = substr(str_shuffle("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 6);
+      return ($this->get_option('invoice_prefix') . $order->get_order_number() . '-' . $suffix);
     }
 
     /**

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -22,7 +22,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     /** @var array Array of locales */
     public $locale;
 
-    /** @var boolean Whether or not logging is enabled */
+    /** @var bool Whether or not logging is enabled */
     public static $log_enabled;
 
     /** @var WC_Logger Logger instance */
@@ -31,19 +31,20 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     /**
      * Constructor for the gateway.
      */
-    public function __construct() {
-        $this->id                	= 'komoju';
-        $this->icon              	= apply_filters('woocommerce_komoju_icon', plugins_url('assets/images/komoju-logo.png', __FILE__));
-        $this->has_fields         	= true;
-        $this->method_title       	= __( 'Komoju', 'komoju-woocommerce' );
-        $this->method_description 	= __( 'Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.', 'komoju-woocommerce' );
-        $this->debug          		= 'yes' === $this->get_option( 'debug', 'yes' );
-        $this->invoice_prefix		= $this->get_option( 'invoice_prefix' );
-        $this->accountID     		= $this->get_option( 'accountID' );
-        $this->secretKey     		= $this->get_option( 'secretKey' );
-        $this->webhookSecretToken   = $this->get_option( 'webhookSecretToken' );
-        $this->komoju_api = new KomojuApi( $this->secretKey );
-        self::$log_enabled    		= $this->debug;
+    public function __construct()
+    {
+        $this->id                	  = 'komoju';
+        $this->icon              	  = apply_filters('woocommerce_komoju_icon', plugins_url('assets/images/komoju-logo.png', __FILE__));
+        $this->has_fields         	 = true;
+        $this->method_title       	 = __('Komoju', 'komoju-woocommerce');
+        $this->method_description 	 = __('Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.', 'komoju-woocommerce');
+        $this->debug          		    = 'yes' === $this->get_option('debug', 'yes');
+        $this->invoice_prefix		     = $this->get_option('invoice_prefix');
+        $this->accountID     		     = $this->get_option('accountID');
+        $this->secretKey     		     = $this->get_option('secretKey');
+        $this->webhookSecretToken   = $this->get_option('webhookSecretToken');
+        $this->komoju_api           = new KomojuApi($this->secretKey);
+        self::$log_enabled    		    = $this->debug;
 
         // Load the settings.
         $this->init_form_fields();
@@ -61,8 +62,8 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             $this->enabled = 'no';
             WC_Gateway_Komoju::log('is not valid for use. No IPN set.');
         } else {
-            include_once( 'includes/class-wc-gateway-komoju-ipn-handler.php' );
-            new WC_Gateway_Komoju_IPN_Handler( $this, $this->webhookSecretToken, $this->secretKey, $this->invoice_prefix );
+            include_once 'includes/class-wc-gateway-komoju-ipn-handler.php';
+            new WC_Gateway_Komoju_IPN_Handler($this, $this->webhookSecretToken, $this->secretKey, $this->invoice_prefix);
         }
     }
 
@@ -120,29 +121,30 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
      *
      * @return array
      */
-    public function process_payment( $order_id ) {
-        include_once( 'includes/class-wc-gateway-komoju-request.php' );
-        $order          = wc_get_order( $order_id );
-        $payment_method = array(sanitize_text_field($_POST['komoju-method']));
-        $return_url = $this->get_mydefault_api_url();
+    public function process_payment($order_id)
+    {
+        include_once 'includes/class-wc-gateway-komoju-request.php';
+        $order          = wc_get_order($order_id);
+        $payment_method = [sanitize_text_field($_POST['komoju-method'])];
+        $return_url     = $this->get_mydefault_api_url();
 
         // new session
-        $komoju_api = $this->komoju_api;
+        $komoju_api     = $this->komoju_api;
         $komoju_request = $komoju_api->createSession([
-            'return_url'  => $return_url,
+            'return_url'     => $return_url,
             'default_locale' => $this->get_locale_or_fallback(),
-            'payment_types' => $payment_method,
-            'payment_data' => [
-                'amount' => $order->get_total(),
-                'currency' => get_woocommerce_currency(),
-                'external_order_num' => $this->external_order_num( $order )
+            'payment_types'  => $payment_method,
+            'payment_data'   => [
+                'amount'             => $order->get_total(),
+                'currency'           => get_woocommerce_currency(),
+                'external_order_num' => $this->external_order_num($order),
             ],
         ]);
 
-        return array(
+        return [
             'result'   => 'success',
-            'redirect' => $komoju_request->session_url
-        );
+            'redirect' => $komoju_request->session_url,
+        ];
     }
 
     /**
@@ -155,11 +157,14 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
 
     /**
      * set KOMOJU side reference for order
+     *
      * @param WC_Order $order
      */
-    private function external_order_num( $order ) {
-      $suffix = substr(str_shuffle("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 6);
-      return ($this->get_option('invoice_prefix') . $order->get_order_number() . '-' . $suffix);
+    private function external_order_num($order)
+    {
+        $suffix = substr(str_shuffle('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 6);
+
+        return $this->get_option('invoice_prefix') . $order->get_order_number() . '-' . $suffix;
     }
 
     /**
@@ -195,7 +200,8 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
         return WC()->api_request_url('WC_Gateway_Komoju');
     }
 
-    private function get_input_field_data() {
+    private function get_input_field_data()
+    {
         $komoju_client = $this->komoju_api;
 
         try {
@@ -266,6 +272,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
 
             return false;
         }
+
         return true;
     }
 }

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -123,28 +123,25 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     public function process_payment( $order_id ) {
         include_once( 'includes/class-wc-gateway-komoju-request.php' );
         $order          = wc_get_order( $order_id );
-        $default_locale = $this->get_locale_or_fallback();
         $payment_method = array(sanitize_text_field($_POST['komoju-method']));
         $return_url = $this->get_mydefault_api_url();
 
         // new session
         $komoju_api = $this->komoju_api;
         $komoju_request = $komoju_api->createSession([
-          'return_url'  => $return_url,
-          'default_locale' => $this->get_locale_or_fallback(),
-          'payment_types' => $payment_method,
-          'payment_data' => [
-            'amount' => $order->get_total(),
-            'currency' => get_woocommerce_currency(),
-            'external_order_num' => $this->external_order_num( $order )
-          ],
+            'return_url'  => $return_url,
+            'default_locale' => $this->get_locale_or_fallback(),
+            'payment_types' => $payment_method,
+            'payment_data' => [
+                'amount' => $order->get_total(),
+                'currency' => get_woocommerce_currency(),
+                'external_order_num' => $this->external_order_num( $order )
+            ],
         ]);
 
-        // $komoju_request = new WC_Gateway_Komoju_Request( $this );
-
         return array(
-          'result'   => 'success',
-          'redirect' => $komoju_request->session_url
+            'result'   => 'success',
+            'redirect' => $komoju_request->session_url
         );
     }
 

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -66,8 +66,8 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
         if (!empty($entityBody) && $this->validate_hmac($entityBody)) {
             $webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
 
-            // do_action('valid-komoju-standard-ipn-request', $webhookEvent);
-            valid_response($webhookEvent);
+            // NOTE: direct function call doesn't work
+            do_action('valid-komoju-standard-ipn-request', $webhookEvent);
             exit;
         }
         wp_die('Komoju IPN Request Failure', 'Komoju IPN', ['response' => 500]);

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -1,249 +1,276 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
 }
 
-include_once( 'class-wc-gateway-komoju-response.php' );
-include_once( 'class-wc-gateway-komoju-webhook-event.php');
+include_once 'class-wc-gateway-komoju-response.php';
+include_once 'class-wc-gateway-komoju-webhook-event.php';
 
 /**
  * Handles responses from Komoju IPN
  */
-class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response {
-
+class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
+{
     protected $gateway;
-	protected $webhookSecretToken;
-	protected $secret_key;
-	protected $invoice_prefix;
-	/**
-	 * Constructor
-	 */
-	public function __construct( $gateway, $webhookSecretToken = '', $secret_key = '', $invoice_prefix = ''  ) {
-		add_action( 'woocommerce_api_wc_gateway_komoju', array( $this, 'check_response' ) );
-		add_action( 'valid-komoju-standard-ipn-request', array( $this, 'valid_response' ) );
+    protected $webhookSecretToken;
+    protected $secret_key;
+    protected $invoice_prefix;
 
-    $this->gateway = $gateway;
-    $this->webhookSecretToken	  	= $webhookSecretToken;
-    $this->secret_key	   	        = $secret_key;
-    $this->invoice_prefix			= $invoice_prefix;
-	}
+    /**
+     * Constructor
+     */
+    public function __construct($gateway, $webhookSecretToken = '', $secret_key = '', $invoice_prefix = '')
+    {
+        add_action('woocommerce_api_wc_gateway_komoju', [$this, 'check_response']);
+        add_action('valid-komoju-standard-ipn-request', [$this, 'valid_response']);
 
-	/**
-	 * Check for Komoju IPN or Session Response
-	 */
-	public function check_response() {
+        $this->gateway                = $gateway;
+        $this->webhookSecretToken	  	 = $webhookSecretToken;
+        $this->secret_key	   	        = $secret_key;
+        $this->invoice_prefix			      = $invoice_prefix;
+    }
 
-      // callback from session page
-      if ( isset( $_GET['session_id'] ) ) {
-          $session = $this->get_session( $_GET['session_id'] );
-          $order = $this->get_order_from_komoju_session( $session, $this->invoice_prefix );
+    /**
+     * Check for Komoju IPN or Session Response
+     */
+    public function check_response()
+    {
+        // callback from session page
+        if (isset($_GET['session_id'])) {
+            $session = $this->get_session($_GET['session_id']);
+            $order   = $this->get_order_from_komoju_session($session, $this->invoice_prefix);
 
-          // null payment on a session indicates incomplete payment flow
-          if ( $session->status === 'completed' && !is_null( $order ) ) {
-              $success_url = $this->gateway->get_return_url( $order );
-              header("Location: { $success_url }");
-              exit;
-          } else {
-              $checkout_url = wc_get_checkout_url();
-              header("Location: { $checkout_url } }");
-              exit;
-          }
-      }
+            // null payment on a session indicates incomplete payment flow
+            if ($session->status === 'completed' && !is_null($order)) {
+                $success_url = $this->gateway->get_return_url($order);
+                header("Location: { $success_url }");
+                exit;
+            } else {
+                $checkout_url = wc_get_checkout_url();
+                header("Location: { $checkout_url } }");
+                exit;
+            }
+        }
 
-      // Webhook (IPN)
-		if ( ! empty( $entityBody ) && $this->validate_hmac($entityBody) ) {
-			$webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
+        // Webhook (IPN)
+        if (!empty($entityBody) && $this->validate_hmac($entityBody)) {
+            $webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
 
-			do_action( "valid-komoju-standard-ipn-request", $webhookEvent );
-			exit;
-		}
-		wp_die( "Komoju IPN Request Failure", "Komoju IPN", array( 'response' => 500 ) );
-	}
+            do_action('valid-komoju-standard-ipn-request', $webhookEvent);
+            exit;
+        }
+        wp_die('Komoju IPN Request Failure', 'Komoju IPN', ['response' => 500]);
+    }
 
-	/**
-	 * There was a valid response
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	public function valid_response( $webhookEvent ) {
-		WC_Gateway_Komoju::log( 'External order num: ' . $webhookEvent->external_order_num() );
-		WC_Gateway_Komoju::log( 'Uuid: ' . $webhookEvent->uuid() );
-		WC_Gateway_Komoju::log( 'Payment status: ' . $webhookEvent->status() );
+    /**
+     * There was a valid response
+     *
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    public function valid_response($webhookEvent)
+    {
+        WC_Gateway_Komoju::log('External order num: ' . $webhookEvent->external_order_num());
+        WC_Gateway_Komoju::log('Uuid: ' . $webhookEvent->uuid());
+        WC_Gateway_Komoju::log('Payment status: ' . $webhookEvent->status());
 
-		$order = $this->get_komoju_order( $webhookEvent, $this->invoice_prefix );
-		if ( $order ) {
-			switch($webhookEvent->status()) {
-				case "captured":
-					$this->payment_status_captured( $order, $webhookEvent );
-					break;
-				case "authorized":
-					$this->payment_status_authorized( $order, $webhookEvent );
-					break;
-				case "expired":
-					$this->payment_status_expired( $order, $webhookEvent );
-					break;
-				case "cancelled":
-					$this->payment_status_cancelled( $order, $webhookEvent );
-					break;
-				case "refunded":
-					$this->payment_status_refunded( $order, $webhookEvent );
-					break;
-				default:
-					WC_Gateway_Komoju::log( "Unknown webhook sent. Webhook type: " . $webhookEvent->event_type() );
-			}
-		}
-	}
+        $order = $this->get_komoju_order($webhookEvent, $this->invoice_prefix);
+        if ($order) {
+            switch ($webhookEvent->status()) {
+                case 'captured':
+                    $this->payment_status_captured($order, $webhookEvent);
+                    break;
+                case 'authorized':
+                    $this->payment_status_authorized($order, $webhookEvent);
+                    break;
+                case 'expired':
+                    $this->payment_status_expired($order, $webhookEvent);
+                    break;
+                case 'cancelled':
+                    $this->payment_status_cancelled($order, $webhookEvent);
+                    break;
+                case 'refunded':
+                    $this->payment_status_refunded($order, $webhookEvent);
+                    break;
+                default:
+                    WC_Gateway_Komoju::log('Unknown webhook sent. Webhook type: ' . $webhookEvent->event_type());
+            }
+        }
+    }
 
-	/**
-	 * Check Komoju IPN validity (hmac control)
-	 * @param string $requestBody the body of the request. Needed to correctly
-	 * calculate the HMAC for comparison.
-	 * @return boolean true/false to indicate whether the hmac is valid
-	 */
-	public function validate_hmac( $requestBody ) {
-		WC_Gateway_Komoju::log( 'Checking if IPN response is valid' );
+    /**
+     * Check Komoju IPN validity (hmac control)
+     *
+     * @param string $requestBody the body of the request. Needed to correctly
+     *                            calculate the HMAC for comparison.
+     *
+     * @return bool true/false to indicate whether the hmac is valid
+     */
+    public function validate_hmac($requestBody)
+    {
+        WC_Gateway_Komoju::log('Checking if IPN response is valid');
 
-		$hmacHeader = $_SERVER['HTTP_X_KOMOJU_SIGNATURE'];
+        $hmacHeader = $_SERVER['HTTP_X_KOMOJU_SIGNATURE'];
 
-		$calcHmac = hash_hmac('sha256', $requestBody, $this->webhookSecretToken);
+        $calcHmac = hash_hmac('sha256', $requestBody, $this->webhookSecretToken);
 
-		if ($hmacHeader != $calcHmac){
-			WC_Gateway_Komoju::log( 'hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...' );
-			return false;
-		}
-		return true;
-	}
+        if ($hmacHeader != $calcHmac) {
+            WC_Gateway_Komoju::log('hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...');
 
-	/**
-	 * Check currency from IPN matches the order
-	 * @param  WC_Order $order
-	 * @param  string $currency
-	 */
-	protected function validate_currency( $order, $currency ) {
-		// Validate currency
-		if ( $order->get_currency() != $currency ) {
-			WC_Gateway_Komoju::log( 'Payment error: Currencies do not match (sent "' . $order->get_currency() . '" | returned "' . $currency . '")' );
+            return false;
+        }
 
-			// Put this order on-hold for manual checking
-			$order->update_status( 'on-hold', sprintf( __( 'Validation error: Komoju currencies do not match (code %s).', 'komoju-woocommerce' ), $currency ) );
-			exit;
-		}
-	}
+        return true;
+    }
 
-	/**
-	 * Check payment amount from IPN matches the order
-	 * @param  WC_Order $order
-	 * @param int $amount the order amount
-	 */
-	protected function validate_amount( $order, $amount ) {
-		if ( number_format( $order->get_total(), 2, '.', '' ) != number_format( $amount, 2, '.', '' ) ) {
-			WC_Gateway_Komoju::log( 'Payment error: Amounts do not match (total: ' . $amount . ') for order #'.$order->get_id().'('.$order->get_total().')' );
+    /**
+     * Check currency from IPN matches the order
+     *
+     * @param WC_Order $order
+     * @param string $currency
+     */
+    protected function validate_currency($order, $currency)
+    {
+        // Validate currency
+        if ($order->get_currency() != $currency) {
+            WC_Gateway_Komoju::log('Payment error: Currencies do not match (sent "' . $order->get_currency() . '" | returned "' . $currency . '")');
 
-			// Put this order on-hold for manual checking
-			$order->update_status( 'on-hold', sprintf( __( 'Validation error: Komoju amounts do not match (total %s).', 'komoju-woocommerce' ), $amount ) );
-			exit;
-		}
-	}
+            // Put this order on-hold for manual checking
+            $order->update_status('on-hold', sprintf(__('Validation error: Komoju currencies do not match (code %s).', 'komoju-woocommerce'), $currency));
+            exit;
+        }
+    }
 
-	/**
-	 * Handle a captured payment
-	 * @param  WC_Order $order
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	protected function payment_status_captured( $order, $webhookEvent ) {
-		if ( $order->has_status( 'captured' ) ) {
-			WC_Gateway_Komoju::log( 'Aborting, Order #' . $order->get_id() . ' is already complete.' );
-			exit;
-		}
+    /**
+     * Check payment amount from IPN matches the order
+     *
+     * @param WC_Order $order
+     * @param int $amount the order amount
+     */
+    protected function validate_amount($order, $amount)
+    {
+        if (number_format($order->get_total(), 2, '.', '') != number_format($amount, 2, '.', '')) {
+            WC_Gateway_Komoju::log('Payment error: Amounts do not match (total: ' . $amount . ') for order #' . $order->get_id() . '(' . $order->get_total() . ')');
 
-		$this->validate_currency( $order, $webhookEvent->currency() );
-		$this->validate_amount( $order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee() );
-		$this->save_komoju_meta_data( $order, $webhookEvent );
+            // Put this order on-hold for manual checking
+            $order->update_status('on-hold', sprintf(__('Validation error: Komoju amounts do not match (total %s).', 'komoju-woocommerce'), $amount));
+            exit;
+        }
+    }
 
-		if ( 'captured' === $webhookEvent->status() ) {
-			$this->payment_complete( $order, ( ! empty( $webhookEvent->external_order_num() ) ? wc_clean( $webhookEvent->external_order_num() ) : '' ), __( 'IPN payment captured', 'komoju-woocommerce' ) );
+    /**
+     * Handle a captured payment
+     *
+     * @param WC_Order $order
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    protected function payment_status_captured($order, $webhookEvent)
+    {
+        if ($order->has_status('captured')) {
+            WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already complete.');
+            exit;
+        }
 
-			if ( ! empty( $webhookEvent->payment_method_fee() ) ) {
-				// log komoju transaction fee
-				update_post_meta( $order->get_id(), 'Payment Gateway Transaction Fee', wc_clean( $webhookEvent->payment_method_fee() ) );
-			}
+        $this->validate_currency($order, $webhookEvent->currency());
+        $this->validate_amount($order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee());
+        $this->save_komoju_meta_data($order, $webhookEvent);
 
-		} else {
-			$this->payment_on_hold( $order, sprintf( __( 'Payment pending: %s', 'komoju-woocommerce' ), $webhookEvent->additional_information() ) );
-		}
-	}
+        if ('captured' === $webhookEvent->status()) {
+            $this->payment_complete($order, (!empty($webhookEvent->external_order_num()) ? wc_clean($webhookEvent->external_order_num()) : ''), __('IPN payment captured', 'komoju-woocommerce'));
 
-	/**
-	 * Handle a cancelled payment
-	 * @param  WC_Order $order
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	protected function payment_status_cancelled( $order, $webhookEvent ) {
-		$order->update_status( 'cancelled', sprintf( __( 'Payment %s via IPN.', 'komoju-woocommerce' ), wc_clean( $webhookEvent->status() ) ) );
-	}
+            if (!empty($webhookEvent->payment_method_fee())) {
+                // log komoju transaction fee
+                update_post_meta($order->get_id(), 'Payment Gateway Transaction Fee', wc_clean($webhookEvent->payment_method_fee()));
+            }
+        } else {
+            $this->payment_on_hold($order, sprintf(__('Payment pending: %s', 'komoju-woocommerce'), $webhookEvent->additional_information()));
+        }
+    }
 
-	/**
-	 * Handle an expired payment
-	 * @param  WC_Order $order
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	protected function payment_status_expired( $order, $webhookEvent ) {
-		$this->payment_status_cancelled( $order, $webhookEvent );
-	}
+    /**
+     * Handle a cancelled payment
+     *
+     * @param WC_Order $order
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    protected function payment_status_cancelled($order, $webhookEvent)
+    {
+        $order->update_status('cancelled', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
+    }
 
-	/**
-	 * Handle an authorized payment
-	 * @param  WC_Order $order
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	protected function payment_status_authorized( $order, $webhookEvent ) {
-		$order->update_status( 'pending-payment');
-		$order->add_order_note(sprintf( __( 'Payment %s via IPN.', 'komoju-woocommerce' ), wc_clean( $webhookEvent->status() ) ) );
-	}
+    /**
+     * Handle an expired payment
+     *
+     * @param WC_Order $order
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    protected function payment_status_expired($order, $webhookEvent)
+    {
+        $this->payment_status_cancelled($order, $webhookEvent);
+    }
 
-	/**
-	 * Handle a refunded order
-	 * @param  WC_Order $order
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	protected function payment_status_refunded( $order, $webhookEvent ) {
-		// Only handle full refunds, not partial
-		WC_Gateway_Komoju::log( 'Only handling full refund. Controlling that order total equals amount refunded. Does '.$order->get_total().' equals '.$webhookEvent->grand_total().' ?' );
-		if ( $order->get_total() == ( $webhookEvent->amount_refunded() ) ) {
+    /**
+     * Handle an authorized payment
+     *
+     * @param WC_Order $order
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    protected function payment_status_authorized($order, $webhookEvent)
+    {
+        $order->update_status('pending-payment');
+        $order->add_order_note(sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
+    }
 
-			// Mark order as refunded
-			$order->update_status( 'refunded', sprintf( __( 'Payment %s via IPN.', 'komoju-woocommerce' ), strtolower( $webhookEvent->status() ) ) );
-		}
-	}
+    /**
+     * Handle a refunded order
+     *
+     * @param WC_Order $order
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    protected function payment_status_refunded($order, $webhookEvent)
+    {
+        // Only handle full refunds, not partial
+        WC_Gateway_Komoju::log('Only handling full refund. Controlling that order total equals amount refunded. Does ' . $order->get_total() . ' equals ' . $webhookEvent->grand_total() . ' ?');
+        if ($order->get_total() == ($webhookEvent->amount_refunded())) {
+            // Mark order as refunded
+            $order->update_status('refunded', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), strtolower($webhookEvent->status())));
+        }
+    }
 
     /**
      * Retrieve session from KOMOJU
+     *
      * @param string $session_id
      */
-    private function get_session( $session_id ) {
-        $client = new KomojuApi( $this->secret_key );
+    private function get_session($session_id)
+    {
+        $client = new KomojuApi($this->secret_key);
 
         try {
-            $session = $client->session( $session_id );
+            $session = $client->session($session_id);
+
             return $session;
         } catch (KomojuExceptionBadServer | KomojuExceptionBadJson $e) {
             return null;
         }
-  }
+    }
 
-	/**
-	 * Save important data from the IPN to the order
-	 * @param WC_Order $order
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 */
-	protected function save_komoju_meta_data( $order, $webhookEvent ) {
-		if ( ! empty( $webhookEvent->tax() ) ) {
-			update_post_meta( $order->get_id(), 'Tax', wc_clean( $webhookEvent->tax() ) );
-		}
-		if ( ! empty( $webhookEvent->amount() ) ) {
-			update_post_meta( $order->get_id(), 'Amount', wc_clean( $webhookEvent->amount() ) );
-		}
-		if ( ! empty( $webhookEvent->additional_information() ) ) {
-			update_post_meta( $order->get_id(), 'Additional info', wc_clean( print_r( $webhookEvent->additional_information(), true) ) );
-		}
-	}
+    /**
+     * Save important data from the IPN to the order
+     *
+     * @param WC_Order $order
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     */
+    protected function save_komoju_meta_data($order, $webhookEvent)
+    {
+        if (!empty($webhookEvent->tax())) {
+            update_post_meta($order->get_id(), 'Tax', wc_clean($webhookEvent->tax()));
+        }
+        if (!empty($webhookEvent->amount())) {
+            update_post_meta($order->get_id(), 'Amount', wc_clean($webhookEvent->amount()));
+        }
+        if (!empty($webhookEvent->additional_information())) {
+            update_post_meta($order->get_id(), 'Additional info', wc_clean(print_r($webhookEvent->additional_information(), true)));
+        }
+    }
 }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -46,6 +46,14 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                 $success_url = $this->gateway->get_return_url($order);
                 header("Location: { $success_url }");
                 exit;
+            } elseif is_null($session) {
+                $checkout_url = wc_get_checkout_url();
+                header("Location: { $checkout_url } }");
+                wp_add_notice(
+                  __('Encountered an issue communicating with KOMOJU. Please wait a moment and try again.'),
+                  'error'
+                );
+                exit;
             } else {
                 $checkout_url = wc_get_checkout_url();
                 header("Location: { $checkout_url } }");

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -1,240 +1,249 @@
 <?php
-
-if (!defined('ABSPATH')) {
-    exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
 }
 
-include_once 'class-wc-gateway-komoju-response.php';
-include_once 'class-wc-gateway-komoju-webhook-event.php';
+include_once( 'class-wc-gateway-komoju-response.php' );
+include_once( 'class-wc-gateway-komoju-webhook-event.php');
 
 /**
  * Handles responses from Komoju IPN
  */
-class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
-{
-    protected $webhookSecretToken;
-    protected $secret_key;
-    protected $invoice_prefix;
+class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response {
 
-    /**
-     * Constructor
-     */
-    public function __construct($webhookSecretToken = '', $secret_key = '', $invoice_prefix = '')
-    {
-        add_action('woocommerce_api_wc_gateway_komoju', [$this, 'check_response']);
-        add_action('valid-komoju-standard-ipn-request', [$this, 'valid_response']);
+  protected $gateway;
+	protected $webhookSecretToken;
+	protected $secret_key;
+	protected $invoice_prefix;
+	/**
+	 * Constructor
+	 */
+	public function __construct( $gateway, $webhookSecretToken = '', $secret_key = '', $invoice_prefix = ''  ) {
+		add_action( 'woocommerce_api_wc_gateway_komoju', array( $this, 'check_response' ) );
+		add_action( 'valid-komoju-standard-ipn-request', array( $this, 'valid_response' ) );
 
-        $this->webhookSecretToken = $webhookSecretToken;
-        $this->secret_key         = $secret_key;
-        $this->invoice_prefix     = $invoice_prefix;
+    $this->gateway = $gateway;
+    $this->webhookSecretToken	  	= $webhookSecretToken;
+    $this->secret_key	   	        = $secret_key;
+    $this->invoice_prefix			= $invoice_prefix;
+	}
+
+	/**
+	 * Check for Komoju IPN or Session Response
+	 */
+	public function check_response() {
+
+    // callback from session page
+    if ( isset( $_GET['session_id'] ) ) {
+      $session = $this->get_session( $_GET['session_id'] );
+      $order = $this->get_order_from_komoju_session( $session, $this->invoice_prefix );
+
+      // null payment on a session indicates incomplete payment flow
+      if ( $session->status === 'completed' && !is_null( $order ) ) {
+        $success_url = $this->gateway->get_return_url( $order );
+        header("Location: { $success_url }");
+        exit;
+      } else {
+        $checkout_url = wc_get_checkout_url();
+        header("Location: { $checkout_url } }");
+        exit;
+      }
     }
 
-    /**
-     * Check for Komoju IPN Response
-     */
-    public function check_response()
-    {
-        $entityBody = file_get_contents('php://input');
+    // Webhook (IPN)
+		if ( ! empty( $entityBody ) && $this->validate_hmac($entityBody) ) {
+			$webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
 
-        if (!empty($entityBody) && $this->validate_hmac($entityBody)) {
-            $webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
+			do_action( "valid-komoju-standard-ipn-request", $webhookEvent );
+			exit;
+		}
+		wp_die( "Komoju IPN Request Failure", "Komoju IPN", array( 'response' => 500 ) );
+	}
 
-            do_action('valid-komoju-standard-ipn-request', $webhookEvent);
-            exit;
-        }
-        wp_die('Komoju IPN Request Failure', 'Komoju IPN', ['response' => 500]);
+	/**
+	 * There was a valid response
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	public function valid_response( $webhookEvent ) {
+		WC_Gateway_Komoju::log( 'External order num: ' . $webhookEvent->external_order_num() );
+		WC_Gateway_Komoju::log( 'Uuid: ' . $webhookEvent->uuid() );
+		WC_Gateway_Komoju::log( 'Payment status: ' . $webhookEvent->status() );
+
+		$order = $this->get_komoju_order( $webhookEvent, $this->invoice_prefix );
+		if ( $order ) {
+			switch($webhookEvent->status()) {
+				case "captured":
+					$this->payment_status_captured( $order, $webhookEvent );
+					break;
+				case "authorized":
+					$this->payment_status_authorized( $order, $webhookEvent );
+					break;
+				case "expired":
+					$this->payment_status_expired( $order, $webhookEvent );
+					break;
+				case "cancelled":
+					$this->payment_status_cancelled( $order, $webhookEvent );
+					break;
+				case "refunded":
+					$this->payment_status_refunded( $order, $webhookEvent );
+					break;
+				default:
+					WC_Gateway_Komoju::log( "Unknown webhook sent. Webhook type: " . $webhookEvent->event_type() );
+			}
+		}
+	}
+
+	/**
+	 * Check Komoju IPN validity (hmac control)
+	 * @param string $requestBody the body of the request. Needed to correctly
+	 * calculate the HMAC for comparison.
+	 * @return boolean true/false to indicate whether the hmac is valid
+	 */
+	public function validate_hmac( $requestBody ) {
+		WC_Gateway_Komoju::log( 'Checking if IPN response is valid' );
+
+		$hmacHeader = $_SERVER['HTTP_X_KOMOJU_SIGNATURE'];
+
+		$calcHmac = hash_hmac('sha256', $requestBody, $this->webhookSecretToken);
+
+		if ($hmacHeader != $calcHmac){
+			WC_Gateway_Komoju::log( 'hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...' );
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Check currency from IPN matches the order
+	 * @param  WC_Order $order
+	 * @param  string $currency
+	 */
+	protected function validate_currency( $order, $currency ) {
+		// Validate currency
+		if ( $order->get_currency() != $currency ) {
+			WC_Gateway_Komoju::log( 'Payment error: Currencies do not match (sent "' . $order->get_currency() . '" | returned "' . $currency . '")' );
+
+			// Put this order on-hold for manual checking
+			$order->update_status( 'on-hold', sprintf( __( 'Validation error: Komoju currencies do not match (code %s).', 'komoju-woocommerce' ), $currency ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Check payment amount from IPN matches the order
+	 * @param  WC_Order $order
+	 * @param int $amount the order amount
+	 */
+	protected function validate_amount( $order, $amount ) {
+		if ( number_format( $order->get_total(), 2, '.', '' ) != number_format( $amount, 2, '.', '' ) ) {
+			WC_Gateway_Komoju::log( 'Payment error: Amounts do not match (total: ' . $amount . ') for order #'.$order->get_id().'('.$order->get_total().')' );
+
+			// Put this order on-hold for manual checking
+			$order->update_status( 'on-hold', sprintf( __( 'Validation error: Komoju amounts do not match (total %s).', 'komoju-woocommerce' ), $amount ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Handle a captured payment
+	 * @param  WC_Order $order
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	protected function payment_status_captured( $order, $webhookEvent ) {
+		if ( $order->has_status( 'captured' ) ) {
+			WC_Gateway_Komoju::log( 'Aborting, Order #' . $order->get_id() . ' is already complete.' );
+			exit;
+		}
+
+		$this->validate_currency( $order, $webhookEvent->currency() );
+		$this->validate_amount( $order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee() );
+		$this->save_komoju_meta_data( $order, $webhookEvent );
+
+		if ( 'captured' === $webhookEvent->status() ) {
+			$this->payment_complete( $order, ( ! empty( $webhookEvent->external_order_num() ) ? wc_clean( $webhookEvent->external_order_num() ) : '' ), __( 'IPN payment captured', 'komoju-woocommerce' ) );
+
+			if ( ! empty( $webhookEvent->payment_method_fee() ) ) {
+				// log komoju transaction fee
+				update_post_meta( $order->get_id(), 'Payment Gateway Transaction Fee', wc_clean( $webhookEvent->payment_method_fee() ) );
+			}
+
+		} else {
+			$this->payment_on_hold( $order, sprintf( __( 'Payment pending: %s', 'komoju-woocommerce' ), $webhookEvent->additional_information() ) );
+		}
+	}
+
+	/**
+	 * Handle a cancelled payment
+	 * @param  WC_Order $order
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	protected function payment_status_cancelled( $order, $webhookEvent ) {
+		$order->update_status( 'cancelled', sprintf( __( 'Payment %s via IPN.', 'komoju-woocommerce' ), wc_clean( $webhookEvent->status() ) ) );
+	}
+
+	/**
+	 * Handle an expired payment
+	 * @param  WC_Order $order
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	protected function payment_status_expired( $order, $webhookEvent ) {
+		$this->payment_status_cancelled( $order, $webhookEvent );
+	}
+
+	/**
+	 * Handle an authorized payment
+	 * @param  WC_Order $order
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	protected function payment_status_authorized( $order, $webhookEvent ) {
+		$order->update_status( 'pending-payment');
+		$order->add_order_note(sprintf( __( 'Payment %s via IPN.', 'komoju-woocommerce' ), wc_clean( $webhookEvent->status() ) ) );
+	}
+
+	/**
+	 * Handle a refunded order
+	 * @param  WC_Order $order
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	protected function payment_status_refunded( $order, $webhookEvent ) {
+		// Only handle full refunds, not partial
+		WC_Gateway_Komoju::log( 'Only handling full refund. Controlling that order total equals amount refunded. Does '.$order->get_total().' equals '.$webhookEvent->grand_total().' ?' );
+		if ( $order->get_total() == ( $webhookEvent->amount_refunded() ) ) {
+
+			// Mark order as refunded
+			$order->update_status( 'refunded', sprintf( __( 'Payment %s via IPN.', 'komoju-woocommerce' ), strtolower( $webhookEvent->status() ) ) );
+		}
+	}
+
+  /**
+   * Retrieve session from KOMOJU
+   * @param string $session_id
+   */
+  private function get_session( $session_id ) {
+    $client = new KomojuApi( $this->secret_key );
+
+    try {
+      $session = $client->session( $session_id );
+      return $session;
+    } catch (KomojuExceptionBadServer | KomojuExceptionBadJson $e) {
+      return null;
     }
+  }
 
-    /**
-     * There was a valid response
-     *
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    public function valid_response($webhookEvent)
-    {
-        WC_Gateway_Komoju::log('External order num: ' . $webhookEvent->external_order_num());
-        WC_Gateway_Komoju::log('Uuid: ' . $webhookEvent->uuid());
-        WC_Gateway_Komoju::log('Payment status: ' . $webhookEvent->status());
-
-        $order = $this->get_komoju_order($webhookEvent, $this->invoice_prefix);
-        if ($order) {
-            switch ($webhookEvent->status()) {
-                case 'captured':
-                    $this->payment_status_captured($order, $webhookEvent);
-                    break;
-                case 'authorized':
-                    $this->payment_status_authorized($order, $webhookEvent);
-                    break;
-                case 'expired':
-                    $this->payment_status_expired($order, $webhookEvent);
-                    break;
-                case 'cancelled':
-                    $this->payment_status_cancelled($order, $webhookEvent);
-                    break;
-                case 'refunded':
-                    $this->payment_status_refunded($order, $webhookEvent);
-                    break;
-                default:
-                    WC_Gateway_Komoju::log('Unknown webhook sent. Webhook type: ' . $webhookEvent->event_type());
-            }
-        }
-    }
-
-    /**
-     * Check Komoju IPN validity (hmac control)
-     *
-     * @param string $requestBody the body of the request. Needed to correctly
-     *                            calculate the HMAC for comparison.
-     *
-     * @return bool true/false to indicate whether the hmac is valid
-     */
-    public function validate_hmac($requestBody)
-    {
-        WC_Gateway_Komoju::log('Checking if IPN response is valid');
-
-        $hmacHeader = $_SERVER['HTTP_X_KOMOJU_SIGNATURE'];
-
-        $calcHmac = hash_hmac('sha256', $requestBody, $this->webhookSecretToken);
-
-        if ($hmacHeader != $calcHmac) {
-            WC_Gateway_Komoju::log('hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...');
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Check currency from IPN matches the order
-     *
-     * @param WC_Order $order
-     * @param string $currency
-     */
-    protected function validate_currency($order, $currency)
-    {
-        // Validate currency
-        if ($order->get_currency() != $currency) {
-            WC_Gateway_Komoju::log('Payment error: Currencies do not match (sent "' . $order->get_currency() . '" | returned "' . $currency . '")');
-
-            // Put this order on-hold for manual checking
-            $order->update_status('on-hold', sprintf(__('Validation error: Komoju currencies do not match (code %s).', 'komoju-woocommerce'), $currency));
-            exit;
-        }
-    }
-
-    /**
-     * Check payment amount from IPN matches the order
-     *
-     * @param WC_Order $order
-     * @param int $amount the order amount
-     */
-    protected function validate_amount($order, $amount)
-    {
-        if (number_format($order->get_total(), 2, '.', '') != number_format($amount, 2, '.', '')) {
-            WC_Gateway_Komoju::log('Payment error: Amounts do not match (total: ' . $amount . ') for order #' . $order->get_id() . '(' . $order->get_total() . ')');
-
-            // Put this order on-hold for manual checking
-            $order->update_status('on-hold', sprintf(__('Validation error: Komoju amounts do not match (total %s).', 'komoju-woocommerce'), $amount));
-            exit;
-        }
-    }
-
-    /**
-     * Handle a captured payment
-     *
-     * @param WC_Order $order
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    protected function payment_status_captured($order, $webhookEvent)
-    {
-        if ($order->has_status('captured')) {
-            WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already complete.');
-            exit;
-        }
-
-        $this->validate_currency($order, $webhookEvent->currency());
-        $this->validate_amount($order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee());
-        $this->save_komoju_meta_data($order, $webhookEvent);
-
-        if ('captured' === $webhookEvent->status()) {
-            $this->payment_complete($order, (!empty($webhookEvent->external_order_num()) ? wc_clean($webhookEvent->external_order_num()) : ''), __('IPN payment captured', 'komoju-woocommerce'));
-
-            if (!empty($webhookEvent->payment_method_fee())) {
-                // log komoju transaction fee
-                update_post_meta($order->get_id(), 'Payment Gateway Transaction Fee', wc_clean($webhookEvent->payment_method_fee()));
-            }
-        } else {
-            $this->payment_on_hold($order, sprintf(__('Payment pending: %s', 'komoju-woocommerce'), $webhookEvent->additional_information()));
-        }
-    }
-
-    /**
-     * Handle a cancelled payment
-     *
-     * @param WC_Order $order
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    protected function payment_status_cancelled($order, $webhookEvent)
-    {
-        $order->update_status('cancelled', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
-    }
-
-    /**
-     * Handle an expired payment
-     *
-     * @param WC_Order $order
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    protected function payment_status_expired($order, $webhookEvent)
-    {
-        $this->payment_status_cancelled($order, $webhookEvent);
-    }
-
-    /**
-     * Handle an authorized payment
-     *
-     * @param WC_Order $order
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    protected function payment_status_authorized($order, $webhookEvent)
-    {
-        $order->update_status('pending-payment');
-        $order->add_order_note(sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
-    }
-
-    /**
-     * Handle a refunded order
-     *
-     * @param WC_Order $order
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    protected function payment_status_refunded($order, $webhookEvent)
-    {
-        // Only handle full refunds, not partial
-        WC_Gateway_Komoju::log('Only handling full refund. Controlling that order total equals amount refunded. Does ' . $order->get_total() . ' equals ' . $webhookEvent->grand_total() . ' ?');
-        if ($order->get_total() == ($webhookEvent->amount_refunded())) {
-            // Mark order as refunded
-            $order->update_status('refunded', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), strtolower($webhookEvent->status())));
-        }
-    }
-
-    /**
-     * Save important data from the IPN to the order
-     *
-     * @param WC_Order $order
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     */
-    protected function save_komoju_meta_data($order, $webhookEvent)
-    {
-        if (!empty($webhookEvent->tax())) {
-            update_post_meta($order->get_id(), 'Tax', wc_clean($webhookEvent->tax()));
-        }
-        if (!empty($webhookEvent->amount())) {
-            update_post_meta($order->get_id(), 'Amount', wc_clean($webhookEvent->amount()));
-        }
-        if (!empty($webhookEvent->additional_information())) {
-            update_post_meta($order->get_id(), 'Additional info', wc_clean(print_r($webhookEvent->additional_information(), true)));
-        }
-    }
+	/**
+	 * Save important data from the IPN to the order
+	 * @param WC_Order $order
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 */
+	protected function save_komoju_meta_data( $order, $webhookEvent ) {
+		if ( ! empty( $webhookEvent->tax() ) ) {
+			update_post_meta( $order->get_id(), 'Tax', wc_clean( $webhookEvent->tax() ) );
+		}
+		if ( ! empty( $webhookEvent->amount() ) ) {
+			update_post_meta( $order->get_id(), 'Amount', wc_clean( $webhookEvent->amount() ) );
+		}
+		if ( ! empty( $webhookEvent->additional_information() ) ) {
+			update_post_meta( $order->get_id(), 'Additional info', wc_clean( print_r( $webhookEvent->additional_information(), true) ) );
+		}
+	}
 }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -46,7 +46,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                 $success_url = $this->gateway->get_return_url($order);
                 header("Location: { $success_url }");
                 exit;
-            } elseif is_null($session) {
+            } elseif (is_null($session)) {
                 $checkout_url = wc_get_checkout_url();
                 header("Location: { $checkout_url } }");
                 wp_add_notice(

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -11,7 +11,7 @@ include_once( 'class-wc-gateway-komoju-webhook-event.php');
  */
 class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response {
 
-  protected $gateway;
+    protected $gateway;
 	protected $webhookSecretToken;
 	protected $secret_key;
 	protected $invoice_prefix;
@@ -33,24 +33,24 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response {
 	 */
 	public function check_response() {
 
-    // callback from session page
-    if ( isset( $_GET['session_id'] ) ) {
-      $session = $this->get_session( $_GET['session_id'] );
-      $order = $this->get_order_from_komoju_session( $session, $this->invoice_prefix );
+      // callback from session page
+      if ( isset( $_GET['session_id'] ) ) {
+          $session = $this->get_session( $_GET['session_id'] );
+          $order = $this->get_order_from_komoju_session( $session, $this->invoice_prefix );
 
-      // null payment on a session indicates incomplete payment flow
-      if ( $session->status === 'completed' && !is_null( $order ) ) {
-        $success_url = $this->gateway->get_return_url( $order );
-        header("Location: { $success_url }");
-        exit;
-      } else {
-        $checkout_url = wc_get_checkout_url();
-        header("Location: { $checkout_url } }");
-        exit;
+          // null payment on a session indicates incomplete payment flow
+          if ( $session->status === 'completed' && !is_null( $order ) ) {
+              $success_url = $this->gateway->get_return_url( $order );
+              header("Location: { $success_url }");
+              exit;
+          } else {
+              $checkout_url = wc_get_checkout_url();
+              header("Location: { $checkout_url } }");
+              exit;
+          }
       }
-    }
 
-    // Webhook (IPN)
+      // Webhook (IPN)
 		if ( ! empty( $entityBody ) && $this->validate_hmac($entityBody) ) {
 			$webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
 
@@ -215,19 +215,19 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response {
 		}
 	}
 
-  /**
-   * Retrieve session from KOMOJU
-   * @param string $session_id
-   */
-  private function get_session( $session_id ) {
-    $client = new KomojuApi( $this->secret_key );
+    /**
+     * Retrieve session from KOMOJU
+     * @param string $session_id
+     */
+    private function get_session( $session_id ) {
+        $client = new KomojuApi( $this->secret_key );
 
-    try {
-      $session = $client->session( $session_id );
-      return $session;
-    } catch (KomojuExceptionBadServer | KomojuExceptionBadJson $e) {
-      return null;
-    }
+        try {
+            $session = $client->session( $session_id );
+            return $session;
+        } catch (KomojuExceptionBadServer | KomojuExceptionBadJson $e) {
+            return null;
+        }
   }
 
 	/**

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -44,11 +44,11 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             // null payment on a session indicates incomplete payment flow
             if ($session->status === 'completed' && !is_null($order)) {
                 $success_url = $this->gateway->get_return_url($order);
-                header("Location: { $success_url }");
+                wp_redirect($success_url);
                 exit;
             } elseif (is_null($session)) {
                 $checkout_url = wc_get_checkout_url();
-                header("Location: { $checkout_url } }");
+                wp_redirect($checkout_url);
                 wp_add_notice(
                   __('Encountered an issue communicating with KOMOJU. Please wait a moment and try again.'),
                   'error'
@@ -56,16 +56,18 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                 exit;
             } else {
                 $checkout_url = wc_get_checkout_url();
-                header("Location: { $checkout_url } }");
+                wp_redirect($checkout_url);
                 exit;
             }
         }
 
         // Webhook (IPN)
+        $entityBody = file_get_contents('php://input');
         if (!empty($entityBody) && $this->validate_hmac($entityBody)) {
             $webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
 
-            do_action('valid-komoju-standard-ipn-request', $webhookEvent);
+            // do_action('valid-komoju-standard-ipn-request', $webhookEvent);
+            valid_response($webhookEvent);
             exit;
         }
         wp_die('Komoju IPN Request Failure', 'Komoju IPN', ['response' => 500]);

--- a/includes/class-wc-gateway-komoju-response.php
+++ b/includes/class-wc-gateway-komoju-response.php
@@ -4,75 +4,86 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-abstract class WC_Gateway_Komoju_Response {
+abstract class WC_Gateway_Komoju_Response
+{
+    /**
+     * Get the order from the Komoju 'transaction' variable
+     *
+     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+     * @param string $invoice_prefix set as an option in Komoju plugin dashboard
+     *
+     * @return bool|WC_Order object
+     */
+    protected function get_komoju_order($webhookEvent, $invoice_prefix)
+    {
+        // We have the data in the correct format, so get the order
+        if (is_string($webhookEvent->external_order_num())) {
+            $order_id = $webhookEvent->external_order_num();
 
-	/**
-	 * Get the order from the Komoju 'transaction' variable
-	 *
-	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-	 * @param  string $invoice_prefix set as an option in Komoju plugin dashboard
-	 * @return bool|WC_Order object
-	 */
-	protected function get_komoju_order( $webhookEvent, $invoice_prefix ) {
-		// We have the data in the correct format, so get the order
-		if ( is_string( $webhookEvent->external_order_num() ) ){
-			$order_id = $webhookEvent->external_order_num();
+        // Nothing was found
+        } else {
+            WC_Gateway_Komoju::log('Error: Order ID (external_order_num) was not found in "webhookEvent".');
 
-			// Nothing was found
-		} else {
-			WC_Gateway_Komoju::log( 'Error: Order ID (external_order_num) was not found in "webhookEvent".' );
-			return false;
-		}
+            return false;
+        }
 
-		if ( ! $order = wc_get_order( substr( $order_id, strlen( $invoice_prefix ), -7) ) ) {
-			WC_Gateway_Komoju::log( 'Error: Cannot locate order in WC with order_id: .'.$order_id.' minus prefix: '.$invoice_prefix );
-			return false;
-		}
+        if (!$order = wc_get_order(substr($order_id, strlen($invoice_prefix), -7))) {
+            WC_Gateway_Komoju::log('Error: Cannot locate order in WC with order_id: .' . $order_id . ' minus prefix: ' . $invoice_prefix);
 
-		return $order;
-	}
+            return false;
+        }
+
+        return $order;
+    }
 
     /**
      * Get an order from a payment associated with a KOMOJU session
+     *
      * @param string $session_id
-     * @param  string $invoice_prefix set as an option in Komoju plugin dashboard
+     * @param string $invoice_prefix set as an option in Komoju plugin dashboard
      */
-    protected function get_order_from_komoju_session( $session, $invoice_prefix ) {
+    protected function get_order_from_komoju_session($session, $invoice_prefix)
+    {
         $payment = $session->payment;
-        if ( is_null( $payment )) {
+        if (is_null($payment)) {
             return null;
         }
 
         $order_id = $payment->external_order_num;
-        $order = wc_get_order( substr( $order_id, strlen( $invoice_prefix ), -7) );
+        $order    = wc_get_order(substr($order_id, strlen($invoice_prefix), -7));
 
-        if ( ! $order ) {
-            WC_Gateway_Komoju::log( 'Error: Cannot locate order in WC with order_id: .'.$order_id.' minus prefix: '.$invoice_prefix );
+        if (!$order) {
+            WC_Gateway_Komoju::log('Error: Cannot locate order in WC with order_id: .' . $order_id . ' minus prefix: ' . $invoice_prefix);
+
             return null;
         }
 
         return $order;
     }
 
-	/**
-	 * Complete order, add transaction ID and note
-	 * @param  WC_Order $order
-	 * @param  string $txn_id
-	 * @param  string $note
-	 */
-	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
-		$order->add_order_note( $note );
-		$order->payment_complete( $txn_id );
-	}
+    /**
+     * Complete order, add transaction ID and note
+     *
+     * @param WC_Order $order
+     * @param string $txn_id
+     * @param string $note
+     */
+    protected function payment_complete($order, $txn_id = '', $note = '')
+    {
+        $order->add_order_note($note);
+        $order->payment_complete($txn_id);
+    }
 
-	/**
-	 * Hold order and add note
-	 * @param  WC_Order $order
-	 * @param  string $reason
-	 */
-	protected function payment_on_hold( $order, $reason = '' ) {
-		$order->update_status( 'on-hold', $reason );
-		$order->reduce_order_stock();
-		WC()->cart->empty_cart();
-	}
+    /**
+     * Hold order and add note
+     *
+     * @param WC_Order $order
+     * @param string $reason
+     */
+    protected function payment_on_hold($order, $reason = '')
+    {
+        $order->update_status('on-hold', $reason);
+        $order->reduce_order_stock();
+        WC()->cart->empty_cart();
+    }
 }

--- a/includes/class-wc-gateway-komoju-response.php
+++ b/includes/class-wc-gateway-komoju-response.php
@@ -4,61 +4,75 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-abstract class WC_Gateway_Komoju_Response
-{
+abstract class WC_Gateway_Komoju_Response {
+
+	/**
+	 * Get the order from the Komoju 'transaction' variable
+	 *
+	 * @param  WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
+	 * @param  string $invoice_prefix set as an option in Komoju plugin dashboard
+	 * @return bool|WC_Order object
+	 */
+	protected function get_komoju_order( $webhookEvent, $invoice_prefix ) {
+		// We have the data in the correct format, so get the order
+		if ( is_string( $webhookEvent->external_order_num() ) ){
+			$order_id = $webhookEvent->external_order_num();
+
+			// Nothing was found
+		} else {
+			WC_Gateway_Komoju::log( 'Error: Order ID (external_order_num) was not found in "webhookEvent".' );
+			return false;
+		}
+
+		if ( ! $order = wc_get_order( substr( $order_id, strlen( $invoice_prefix ), -7) ) ) {
+			WC_Gateway_Komoju::log( 'Error: Cannot locate order in WC with order_id: .'.$order_id.' minus prefix: '.$invoice_prefix );
+			return false;
+		}
+
+		return $order;
+	}
+
     /**
-     * Get the order from the Komoju 'transaction' variable
-     *
-     * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     * @param string $invoice_prefix set as an option in Komoju plugin dashboard
-     *
-     * @return bool|WC_Order object
+     * Get an order from a payment associated with a KOMOJU session
+     * @param string $session_id
+     * @param  string $invoice_prefix set as an option in Komoju plugin dashboard
      */
-    protected function get_komoju_order($webhookEvent, $invoice_prefix)
-    {
-        // We have the data in the correct format, so get the order
-        if (is_string($webhookEvent->external_order_num())) {
-            $order_id = $webhookEvent->external_order_num();
-
-        // Nothing was found
-        } else {
-            WC_Gateway_Komoju::log('Error: Order ID (external_order_num) was not found in "webhookEvent".');
-
-            return false;
+    protected function get_order_from_komoju_session( $session, $invoice_prefix ) {
+        $payment = $session->payment;
+        if ( is_null( $payment )) {
+            return null;
         }
 
-        if (!$order = wc_get_order(substr($order_id, strlen($invoice_prefix), -7))) {
-            WC_Gateway_Komoju::log('Error: Cannot locate order in WC with order_id: .' . $order_id . ' minus prefix: ' . $invoice_prefix);
+        $order_id = $payment->external_order_num;
+        $order = wc_get_order( substr( $order_id, strlen( $invoice_prefix ), -7) );
 
-            return false;
+        if ( ! $order ) {
+            WC_Gateway_Komoju::log( 'Error: Cannot locate order in WC with order_id: .'.$order_id.' minus prefix: '.$invoice_prefix );
+            return null;
         }
 
         return $order;
     }
 
-    /**
-     * Complete order, add transaction ID and note
-     *
-     * @param WC_Order $order
-     * @param string $txn_id
-     * @param string $note
-     */
-    protected function payment_complete($order, $txn_id = '', $note = '')
-    {
-        $order->add_order_note($note);
-        $order->payment_complete($txn_id);
-    }
+	/**
+	 * Complete order, add transaction ID and note
+	 * @param  WC_Order $order
+	 * @param  string $txn_id
+	 * @param  string $note
+	 */
+	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
+		$order->add_order_note( $note );
+		$order->payment_complete( $txn_id );
+	}
 
-    /**
-     * Hold order and add note
-     *
-     * @param WC_Order $order
-     * @param string $reason
-     */
-    protected function payment_on_hold($order, $reason = '')
-    {
-        $order->update_status('on-hold', $reason);
-        $order->reduce_order_stock();
-        WC()->cart->empty_cart();
-    }
+	/**
+	 * Hold order and add note
+	 * @param  WC_Order $order
+	 * @param  string $reason
+	 */
+	protected function payment_on_hold( $order, $reason = '' ) {
+		$order->update_status( 'on-hold', $reason );
+		$order->reduce_order_stock();
+		WC()->cart->empty_cart();
+	}
 }

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -4,8 +4,8 @@ class KomojuApi
 {
     public function __construct($secretKey)
     {
-        $this->endpoint = 'https://komoju.com';
-        $this->via = 'woocommerce';
+        $this->endpoint  = 'https://komoju.com';
+        $this->via       = 'woocommerce';
         $this->secretKey = $secretKey;
     }
 
@@ -67,10 +67,10 @@ class KomojuApi
         $data_json = json_encode($payload);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data_json);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-          "Content-Type: application/json",
-          "komoju-via: {$this->via}"
-        ));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            "komoju-via: {$this->via}",
+        ]);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_USERPWD, $this->secretKey . ':');
         $result = curl_exec($ch);

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -4,7 +4,8 @@ class KomojuApi
 {
     public function __construct($secretKey)
     {
-        $this->endpoint  = 'https://komoju.com';
+        $this->endpoint = 'https://komoju.com';
+        $this->via = 'woocommerce';
         $this->secretKey = $secretKey;
     }
 
@@ -66,7 +67,10 @@ class KomojuApi
         $data_json = json_encode($payload);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data_json);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+          "Content-Type: application/json",
+          "komoju-via: {$this->via}"
+        ));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_USERPWD, $this->secretKey . ':');
         $result = curl_exec($ch);


### PR DESCRIPTION
Uses the Sessions API in place of the legacy hosted page.
This PR removes the old request class but retains the logic surrounding the IPN (webhooks)

![Screen Recording 2020-12-10 at 06 47 PM](https://user-images.githubusercontent.com/27859194/101755540-54a0a480-3b18-11eb-96ee-66ff4e00e43e.gif)

Note that redirect after checkout will not work properly until the fix for multiple query parameters is deployed. This PR should not be merged until then

## How to Test
1. `docker-compose up`
2. follow the development setup instructions on this repository
3. add a product to cart and navigate to checkout page 
4. complete the checkout flow