### PR TITLE
Deploy action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.github export-ignore
+/vendor export-ignore
+
+/composer.phar export-ignore
+/composer.lock export-ignore
+
+/docker-compose.yml export-ignore
+/Dockerfile export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 /.github export-ignore
+/bin export-ignore
 /vendor export-ignore
+/docs export-ignore
 
 /composer.phar export-ignore
 /composer.lock export-ignore
+/.php_cs.dist export-ignore
 
+/.env export-ignore
 /docker-compose.yml export-ignore
 /Dockerfile export-ignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  tag:
+    name: Deploy Wordpress Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy plugin
+      - uses: 10up/action-wordpress-plugin-deploy@stable
+    env:
+      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      SLUG: komoju-japanese-payments

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: deploy plugin
-      - uses: 10up/action-wordpress-plugin-deploy@stable
-    env:
-      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-      SLUG: komoju-japanese-payments
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SLUG: komoju-japanese-payments

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     name: Deploy Wordpress Plugin
     runs-on: ubuntu-latest
     steps:
-      - name: deploy plugin
+    - name: deploy plugin
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
Uploading changes manually to the wordpress svn is error prone. Adding an action to automate it

Using a third party action that can be reviewed here: https://github.com/10up/action-wordpress-plugin-deploy 