### PR TITLE
Bump version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update \
     && rm /tmp/relative-url.zip \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
 RUN mkdir -p /var/www/html/wp-content/uploads/wc-logs/ \
     && chown -R www-data /var/www/html/wp-content/uploads/wc-logs/
 

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -212,7 +212,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
         $komoju_client = $this->komoju_api;
 
         try {
-            $methods       = apply_filters( 'woocommerce_komoju_payment_methods', $komoju_client->paymentMethods());
+            $methods       = apply_filters('woocommerce_komoju_payment_methods', $komoju_client->paymentMethods());
             $page_locale   = $this->get_locale_or_fallback();
             $name_property = "name_{$page_locale}";
 

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     2.0.0
+ * @version     2.1.0
  *
  * @author      Komoju
  */

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 2.0.0
+Version: 2.1.0
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -136,3 +136,6 @@ Removed payment method icons on checkout (To be re-added at a later date)
 = 2.0 =
 Introduced new hosted checkout design
 Added option to use 'on-hold' status for authorized payments
+
+= 2.1.0 =
+Added filter 'woocommerce_komoju_payment_methods' to allow users to change the list of offered payment methods to their users.


### PR DESCRIPTION
Bumping version to 2.1.0, to deploy changes in #42.

We've automated the deploy based on pushing tags, so once this PR is approved I'll tag the commit on master as `v2.1.0` and deploy it to WordPress.