### PR TITLE
Fix radio button selection input

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -239,26 +239,25 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
                     validate-required
                     woocommerce-validated"
                 >
-                <label
-                  for="' . esc_attr($this->id) . '-method"
-                >' . __('Method of payment:', 'komoju-woocommerce') . '
+                ' . __('Method of payment:', 'komoju-woocommerce') . '
                   <abbr
                     class="required"
                     title="required"
                   >*
-                  </abbr>
-               </label>';
+                  </abbr>';
             foreach ($methods as $method) {
                 $field_data .= '
-                  <input
-                    id="' . esc_attr($this->id) . '-method"
-                    class="input-radio"
-                    type="radio"
-                    value="' . esc_attr($method->type_slug) . '"
-                    name="' . esc_attr($this->id) . '-method"
-                  />
-                  ' . ($method->{$name_property}) . '
-                  <br/>';
+                  <label>
+                    <input
+                      id="' . esc_attr($this->id) . '-method"
+                      class="input-radio"
+                      type="radio"
+                      value="' . esc_attr($method->type_slug) . '"
+                      name="' . esc_attr($this->id) . '-method"
+                    />
+                    ' . ($method->{$name_property}) . '
+                    <br/>
+                  </label>';
             }
             $field_data .= '</p>';
         } catch (KomojuExceptionBadServer | KomojuExceptionBadJson $e) {


### PR DESCRIPTION
## Context

I noticed clicking on the payment method text does not select the radio input associated with it.
This pull request wraps each input element in a <label> tag so when clicking on the text it will select the radio button input.

Also for some strange reason "Method of payment:" was wrapped in a <label> input tag. I've remove it in this pull request.

![image](https://user-images.githubusercontent.com/82835/154234197-0f8352e2-0be9-45e7-b94b-0ea6ce558dbf.png)
