### PR TITLE
Update plugin name to be KOMOJU Payments

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     2.1.0
+ * @version     2.1.1
  *
  * @author      Komoju
  */

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: KOMOJU
+Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
 Version: 2.1.0

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 2.1.0
+Version: 2.1.1
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== KOMOJU Japanese Payments ===
+=== KOMOJU Payments ===
 Contributors: degica
 Tags: WooCommerce,Payment Gateway,Komoju
 Requires at least: 5.3
@@ -46,7 +46,7 @@ We support businesses that are conducting business cross-border. For the majorit
 
 ### Accepted Payment Methods
 
-We currently accept the following payment methods: 
+We currently accept the following payment methods:
 
 **Japan**
 
@@ -170,3 +170,6 @@ Added option to use 'on-hold' status for authorized payments
 
 = 2.1.0 =
 Added filter 'woocommerce_komoju_payment_methods' to allow users to change the list of offered payment methods to their users.
+
+= 2.1.1 =
+Update Plugin Name


### PR DESCRIPTION
## Context

On the [Wordpress store](https://ja.wordpress.org/plugins/komoju-japanese-payments/) we refer to the plugin as "KOMOJU Japanese Payments". However, we now support a variety of payment methods all around the world, so we should update the plugin details to reflect that.

## How to test
1. Run the app locally with `docker-compose up`
2. go to `http://localhost:8000`
3. Set up your admin account (with whatever details you want)
4. on the dashboard, go the "Plugins" on the side, and confirm you can see "KOMOJU Payments" as the plugin name