### PR TITLE
Feature: Subscriptions support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip wget gettext vim \
     && wget https://downloads.wordpress.org/plugin/woocommerce.${woocommerce_version}.zip -O /tmp/woocommerce.zip \
     && wget https://downloads.wordpress.org/plugin/relative-url.0.1.7.zip -O /tmp/relative-url.zip \
+    && wget https://github.com/wp-premium/woocommerce-subscriptions/archive/refs/tags/3.0.1.zip -O /tmp/woocommerce-subscriptions.zip \
     && cd /usr/src/wordpress/wp-content/plugins \
     && unzip /tmp/woocommerce.zip \
     && unzip /tmp/relative-url.zip \
+    && unzip /tmp/woocommerce-subscriptions.zip \
     && rm /tmp/woocommerce.zip \
     && rm /tmp/relative-url.zip \
+    && rm /tmp/woocommerce-subscriptions.zip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
        context: .
        dockerfile: Dockerfile
        args:
-         woocommerce_version: 4.0.1
+         woocommerce_version: 4.1.0
      ports:
        - "8000:80"
      restart: always

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -29,6 +29,11 @@ class KomojuApi
         return $this->get('/api/v1/sessions/' . $sessionUuid);
     }
 
+    public function createPayment($payload)
+    {
+        return $this->post('/api/v1/payments', $payload);
+    }
+
     private function get($uri)
     {
         $ch = curl_init($this->endpoint . $uri);


### PR DESCRIPTION
Adds support for handling of subscription products.

Flow:
- If subscription product is in the user's cart, will redirect to payment details collection page (customer mode)
- save token to subscription "parent order" metadata
- process parent order payment immediately with token, including any non subscription products
- subscription is "activated" on state transition of parent order. billing cadence is handled entirely by woocommerce configuration/api
- when a renewal payment event is triggered, event handler will read token from the metadata of parent order attached to subscription associated with the renewal order and use it to process payment

Note that each renewal payment has its own state and exists independently as an order, so this flow should work for all payment methods that customer mode supports.