### PR TITLE
Add per-gateway icon toggle

### DIFF
--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -20,7 +20,10 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
         $this->id             = 'komoju_' . $slug;
         $this->has_fields     = false;
         $this->method_title   = __('Komoju', 'komoju-woocommerce') . ' - ' . $this->default_title();
-        $this->icon           = "https://komoju.com/payment_methods/$slug.svg";
+
+        if ($this->get_option('showIcon') == 'yes') {
+            $this->icon = "https://komoju.com/payment_methods/$slug.svg";
+        }
 
         parent::__construct();
     }

--- a/includes/gateway-settings-komoju.php
+++ b/includes/gateway-settings-komoju.php
@@ -15,6 +15,12 @@ return [
         'label'   => __('Enable Komoju', 'komoju-woocommerce'),
         'default' => 'no',
     ],
+    'showIcon' => [
+        'title'       => __('Icon', 'komoju-woocommerce'),
+        'label'       => __('Show icon on checkout', 'komoju-woocommerce'),
+        'type'        => 'checkbox',
+        'default'     => 'yes',
+    ],
     'title' => [
         'title'       => __('Title', 'komoju-woocommerce'),
         'type'        => 'text',

--- a/tests/cypress/integration/checkout.spec.js
+++ b/tests/cypress/integration/checkout.spec.js
@@ -48,4 +48,40 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.contains('Choose a Convenience Store').should('exist');
     cy.location('pathname').should('include', '/sessions/');
   })
+
+  it('lets me turn checkout icons on and off', () => {
+    cy.setupKomoju(['konbini', 'credit_card']);
+    cy.contains('Payments').click();
+    cy.enablePaymentGateway('komoju_credit_card');
+
+    cy.get('[data-gateway_id="komoju_credit_card"] a.button')
+      .click()
+
+    cy.get('#woocommerce_komoju_credit_card_showIcon').then(input => {
+      cy.log(input.attr('checked'));
+      if (input.attr('checked')) input.click()
+    })
+    cy.contains('Save changes').click()
+    cy.contains('Your settings have been saved.').should('exist')
+
+    cy.goToStore();
+    cy.contains('Add to cart').click();
+    cy.contains('Cart').click();
+    cy.contains('Proceed to checkout').click();
+    cy.get('label[for="payment_method_komoju_credit_card"] img').should('not.exist')
+
+    cy.visit('/wp-admin/admin.php?page=wc-settings&tab=checkout')
+    cy.get('[data-gateway_id="komoju_credit_card"] a.button')
+      .click()
+
+    cy.get('#woocommerce_komoju_credit_card_showIcon').click()
+    cy.contains('Save changes').click()
+    cy.contains('Your settings have been saved.').should('exist')
+
+    cy.goToStore();
+    cy.contains('Add to cart').click();
+    cy.contains('Cart').click();
+    cy.contains('Proceed to checkout').click();
+    cy.get('label[for="payment_method_komoju_credit_card"] img').should('exist')
+  })
 });


### PR DESCRIPTION
## Context

This PR adds setting that lets you turn off the icon for any KOMOJU payment gateway.
![image](https://user-images.githubusercontent.com/2793160/174802602-6ba2300e-e10e-4e8b-affe-cfb0f1f19e5c.png)

## How to test

1. If you're not connected to KOMOJU, connect and then select a few payment methods
2. Go to the payments tab
3. Click "set up" or "manage" on one of your KOMOJU payment gateways
4. See the new "Icon" checkbox - uncheck it
5. Go to your storefront, add something to the cart, then checkout
6. You should see that there is no icon next to the payment gateway that you disabled the icon for