### PR TITLE
Support refunding from WooCommerce

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           repository: 'degica/komoju-e2e-tests'
           submodules: recursive
-          ref: 6ce1d1f0a9dd887f97337d520ed920893716ddb4
           token: ${{ secrets.BUNDLER_SSH_KEY }}
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: test
 
 on:
-  - push
+  push:
+    branches:
+      - '*'
 
 jobs:
   cypress-tests:
@@ -22,3 +24,37 @@ jobs:
         with:
           name: screenshots
           path: tests/cypress/screenshots/
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build plugin zip file
+        run: ./build.bash
+      - uses: actions/upload-artifact@v3
+        with:
+          name: komoju-japanese-payments
+          path: komoju-japanese-payments.zip
+          retention-days: 1
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      TARGET: staging
+      WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'degica/komoju-e2e-tests'
+          submodules: recursive
+          token: ${{ secrets.BUNDLER_SSH_KEY }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: komoju-japanese-payments
+      - name: Show files
+        run: ls
+      - name: Set up docker-compose
+        run: |-
+          docker-compose build
+          docker-compose up -d
+      - name: Run e2e tests
+        run: docker-compose run tester rspec spec/woocommerce

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           repository: 'degica/komoju-e2e-tests'
           submodules: recursive
+          ref: 6ce1d1f0a9dd887f97337d520ed920893716ddb4
           token: ${{ secrets.BUNDLER_SSH_KEY }}
       - uses: actions/download-artifact@v3
         with:

--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# This is copy/pasted from the 10up/action-wordpress-plugin-deploy action we
+# use to deploy the plugin. All destructive actions have been removed - just
+# the plugin zip file is generated.
+
+# Note that this does not use pipefail
+# because if the grep later doesn't match any deleted files,
+# which is likely the majority case,
+# it does not exit with a 0, and I only care about the final exit.
+set -eo
+
+SLUG=komoju-japanese-payments
+echo "ℹ︎ SLUG is $SLUG"
+
+VERSION=0.0.0
+echo "ℹ︎ VERSION is $VERSION"
+
+if [[ -z "$ASSETS_DIR" ]]; then
+	ASSETS_DIR=".wordpress-org"
+fi
+echo "ℹ︎ ASSETS_DIR is $ASSETS_DIR"
+
+if [[ -z "$BUILD_DIR" ]] || [[ $BUILD_DIR == "./" ]]; then
+	BUILD_DIR=false
+elif [[ $BUILD_DIR == ./* ]]; then 
+	BUILD_DIR=${BUILD_DIR:2}
+fi
+
+if [[ "$BUILD_DIR" != false ]]; then
+	if [[ $BUILD_DIR != /* ]]; then 
+		BUILD_DIR="${PWD%/}/${BUILD_DIR%/}"
+	fi
+	echo "ℹ︎ BUILD_DIR is $BUILD_DIR"
+fi
+
+GIT_DIR="${PWD}"
+
+SVN_URL="https://plugins.svn.wordpress.org/${SLUG}/"
+SVN_DIR="${PWD}/.svn-${SLUG}"
+
+# Checkout just trunk and assets for efficiency
+# Tagging will be handled on the SVN level
+echo "➤ Checking out .org repository..."
+svn checkout --depth immediates "$SVN_URL" "$SVN_DIR"
+cd "$SVN_DIR"
+svn update --set-depth infinity assets
+svn update --set-depth infinity trunk
+
+
+if [[ "$BUILD_DIR" = false ]]; then
+	echo "➤ Copying files..."
+	if [[ -e "$PWD/.distignore" ]]; then
+		echo "ℹ︎ Using .distignore"
+		# Copy from current branch to /trunk, excluding dotorg assets
+		# The --delete flag will delete anything in destination that no longer exists in source
+		rsync -rc --exclude-from="$PWD/.distignore" "$PWD/" trunk/ --delete --delete-excluded
+	else
+		echo "ℹ︎ Using .gitattributes"
+
+		cd "$GIT_DIR"
+
+		# "Export" a cleaned copy to a temp directory
+		TMP_DIR="/tmp/komoju-woocommerce-tmp"
+                rm -rf "$TMP_DIR"
+		mkdir "$TMP_DIR"
+
+		# This will exclude everything in the .gitattributes file with the export-ignore flag
+		git archive HEAD | tar x --directory="$TMP_DIR"
+
+		cd "$SVN_DIR"
+
+		# Copy from clean copy to /trunk, excluding dotorg assets
+		# The --delete flag will delete anything in destination that no longer exists in source
+		rsync -rc "$TMP_DIR/" trunk/ --delete --delete-excluded
+	fi
+else
+	echo "ℹ︎ Copying files from build directory..."
+	rsync -rc "$BUILD_DIR/" trunk/ --delete --delete-excluded
+fi
+
+# Copy dotorg assets to /assets
+if [[ -d "$PWD/$ASSETS_DIR/" ]]; then
+	rsync -rc "$PWD/$ASSETS_DIR/" assets/ --delete
+else
+	echo "ℹ︎ No assets directory found; skipping asset copy"
+fi
+
+# Add everything and commit to SVN
+# The force flag ensures we recurse into subdirectories even if they are already added
+# Suppress stdout in favor of svn status later for readability
+echo "➤ Preparing files..."
+svn add . --force > /dev/null
+
+# SVN delete all deleted files
+# Also suppress stdout here
+svn status | grep '^\!' | sed 's/! *//' | xargs -I% svn rm %@ > /dev/null
+
+# Copy tag locally to make this a single commit
+echo "➤ Copying tag..."
+svn cp "trunk" "tags/$VERSION"
+
+# Fix screenshots getting force downloaded when clicking them
+# https://developer.wordpress.org/plugins/wordpress-org/plugin-assets/
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.png" -print -quit)"; then
+    svn propset svn:mime-type "image/png" "$SVN_DIR/assets/*.png" || true
+fi
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.jpg" -print -quit)"; then
+    svn propset svn:mime-type "image/jpeg" "$SVN_DIR/assets/*.jpg" || true
+fi
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.gif" -print -quit)"; then
+    svn propset svn:mime-type "image/gif" "$SVN_DIR/assets/*.gif" || true
+fi
+if test -d "$SVN_DIR/assets" && test -n "$(find "$SVN_DIR/assets" -maxdepth 1 -name "*.svg" -print -quit)"; then
+    svn propset svn:mime-type "image/svg+xml" "$SVN_DIR/assets/*.svg" || true
+fi
+
+#Resolves => SVN commit failed: Directory out of date
+svn update
+
+svn status
+
+# echo "➤ Committing files..."
+# svn commit -m "Update to version $VERSION from GitHub" --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+
+if $INPUT_GENERATE_ZIP; then
+  echo "Generating zip file..."
+  cd "$SVN_DIR/trunk" || exit
+  zip -r "${PWD}/${SLUG}.zip" .
+  echo "::set-output name=zip-path::${PWD}/${SLUG}.zip"
+  cp "${PWD}/${SLUG}.zip" $GIT_DIR
+  echo "✓ Zip file generated!"
+fi

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -183,41 +183,6 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     }
 
     /**
-     * Process refund.
-     *
-     * Attempts to refund the passed-in amount with KOMOJU.
-     *
-     * @param int $order_id order ID
-     * @param float|null $amount refund amount
-     * @param string $reason refund reason
-     *
-     * @return bool true or false based on success, or a WP_Error object
-     */
-    public function process_refund($order_id, $amount = null, $reason = '')
-    {
-        $order      = wc_get_order($order_id);
-        $payment_id = $order->get_meta('komoju_payment_id');
-
-        if ($payment_id == '') {
-            return false;
-        }
-
-        $payload = json_encode([
-            'amount'      => $amount,
-            'description' => $reason,
-        ]);
-        $payment = $this->komoju_api->post('/api/v1/payments/' . $payment_id . '/refund', $payload);
-
-        $refund = array_slice($payment->refunds, -1)[0];
-
-        if ($refund && $refund->status == 'completed' && $refund->amount == $amount) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
      * Payment form on checkout page
      */
     public function payment_fields()

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -183,6 +183,41 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     }
 
     /**
+     * Process refund.
+     *
+     * Attempts to refund the passed-in amount with KOMOJU.
+     *
+     * @param int $order_id order ID
+     * @param float|null $amount refund amount
+     * @param string $reason refund reason
+     *
+     * @return bool true or false based on success, or a WP_Error object
+     */
+    public function process_refund($order_id, $amount = null, $reason = '')
+    {
+        $order      = wc_get_order($order_id);
+        $payment_id = $order->get_meta('komoju_payment_id');
+
+        if ($payment_id == '') {
+            return false;
+        }
+
+        $payload = json_encode([
+            'amount'      => $amount,
+            'description' => $reason,
+        ]);
+        $payment = $this->komoju_api->post('/api/v1/payments/' . $payment_id . '/refund', $payload);
+
+        $refund = array_slice($payment->refunds, -1)[0];
+
+        if ($refund && $refund->status == 'completed' && $refund->amount == $amount) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Payment form on checkout page
      */
     public function payment_fields()

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -81,7 +81,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             return;
         }
 
-        $url = $this->komoju_api->endpoint . '/admin/payments/' . $payment_id; ?>
+        $url = $this->komoju_api->endpoint . '/merchant/payments/' . $payment_id; ?>
         <p>
             <a href="<?php echo esc_attr($url); ?>">
                 <?php echo __('View payment on KOMOJU', 'komoju-woocommerce'); ?>

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -175,7 +175,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
         }
 
         // new session
-        $currency       = get_woocommerce_currency();
+        $currency       = $order->get_currency();
         $komoju_api     = $this->komoju_api;
         $session_params = [
             'amount'         => self::to_cents($order->get_total(), $currency),

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -314,5 +314,8 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
         if (!empty($webhookEvent->additional_information())) {
             update_post_meta($order->get_id(), 'Additional info', wc_clean(print_r($webhookEvent->additional_information(), true)));
         }
+        if (!empty($webhookEvent->uuid())) {
+            $order->add_meta_data('komoju_payment_id', $webhookEvent->uuid(), true);
+        }
     }
 }

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -49,6 +49,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
     {
         $order      = wc_get_order($order_id);
         $payment_id = $order->get_meta('komoju_payment_id');
+        $currency   = $order->get_currency();
 
         if ($payment_id == '') {
             return false;
@@ -56,7 +57,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
         $payload = [];
         if (!is_null($amount)) {
-            $payload['amount'] = $amount;
+            $payload['amount'] = self::to_cents($amount, $currency);
         }
         if ($reason != '') {
             $payload['description'] = $reason;
@@ -73,7 +74,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
         $refund = $payment->refunds[count($payment->refunds) - 1];
 
-        if ($refund && $refund->amount == $amount) {
+        if ($refund && $refund->amount == self::to_cents($amount, $currency)) {
             return true;
         } else {
             return false;

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -25,6 +25,12 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
             $this->icon = "https://komoju.com/payment_methods/$slug.svg";
         }
 
+        // TODO: It would be nice if KOMOJU told us in the payment method object whether or
+        // not it supports refunds. For now, we'll just wing it.
+        if (!in_array($slug, ['konbini', 'pay_easy', 'bank_transfer'])) {
+            $this->supports[] = 'refunds';
+        }
+
         parent::__construct();
     }
 

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -44,6 +44,11 @@ class KomojuApi
         return $this->get('/api/v1/sessions/' . $sessionUuid);
     }
 
+    public function refund($paymentUuid, $payload)
+    {
+        return $this->post('/api/v1/payments/' . $paymentUuid . '/refund', $payload);
+    }
+
     private function get($uri, $asArray = false)
     {
         $ch = curl_init($this->endpoint . $uri);


### PR DESCRIPTION
Right now we only sync refunds from KOMOJU. For better plugin interoperability and UX, we'd like to also support refunding from WC.

![image](https://user-images.githubusercontent.com/2793160/175200190-481f86d6-f5db-4e7c-8312-988223d819bb.png)

This PR also adds a CI step that actually tests the feature via our E2E tests.

## To test manually
1. Basic setup: `docker-compose up` and visit http://localhost:8000/wp-admin (install WC and komoju plugins if necessary)
1. You'll need to use ngrok or similar in order to receive webhooks
2. Visit your store via ngrok
3. Go to WooCommerce settings, click the KOMOJU tab, then sign into komoju
4. Enable credit card or some other refundable payment method like paypay
5. Visit your store and buy a product using credit card or paypay
6. Find the order on your WooCommerce admin
7. You should be able to refund it via KOMOJU
8. Check KOMOJU to make sure it's actually refunded