### PR TITLE
Return to pay-order URL instead of checkout

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -167,6 +167,9 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
                 'shipping_address'   => $shipping_address,
             ],
             'line_items' => $line_items,
+            'metadata'   => [
+                'woocommerce_order_id' => $order->get_order_number(),
+            ],
         ];
         $remove_nulls = function ($v) { return !is_null($v); };
         $session_params['payment_data'] = array_filter(

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -47,7 +47,6 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             if ($session->status === 'completed' && !is_null($order)) {
                 $success_url = $this->gateway->get_return_url($order);
                 wp_redirect($success_url);
-                exit;
             } elseif (is_null($session)) {
                 $checkout_url = wc_get_checkout_url();
                 wp_redirect($checkout_url);
@@ -55,12 +54,14 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                   __('Encountered an issue communicating with KOMOJU. Please wait a moment and try again.'),
                   'error'
                 );
-                exit;
-            } else {
+            } elseif (is_null($order)) {
                 $checkout_url = wc_get_checkout_url();
                 wp_redirect($checkout_url);
-                exit;
+            } else {
+                $payment_url = $order->get_checkout_payment_url(false);
+                wp_redirect($payment_url);
             }
+            exit;
         }
 
         // Quick setup POST from KOMOJU

--- a/includes/class-wc-gateway-komoju-response.php
+++ b/includes/class-wc-gateway-komoju-response.php
@@ -44,6 +44,11 @@ abstract class WC_Gateway_Komoju_Response
      */
     protected function get_order_from_komoju_session($session, $invoice_prefix)
     {
+        $order = wc_get_order($session->metadata->woocommerce_order_id);
+        if ($order) {
+            return $order;
+        }
+
         $payment = $session->payment;
         if (is_null($payment)) {
             return null;

--- a/tests/cypress/integration/checkout.spec.js
+++ b/tests/cypress/integration/checkout.spec.js
@@ -104,6 +104,7 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.location('pathname').should('include', '/sessions/');
 
     cy.contains('Back to Merchant').click();
+    cy.reload();
     cy.get('#payment_method_komoju_credit_card').click();
     cy.contains('Pay for order').click();
 

--- a/tests/cypress/integration/checkout.spec.js
+++ b/tests/cypress/integration/checkout.spec.js
@@ -84,4 +84,30 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.contains('Proceed to checkout').click();
     cy.get('label[for="payment_method_komoju_credit_card"] img').should('exist')
   })
+
+  it('lets me change my mind on how to pay for the same order', () => {
+    cy.setupKomoju(['konbini', 'credit_card']);
+    cy.contains('Payments').click();
+    cy.enablePaymentGateway('komoju_konbini');
+    cy.enablePaymentGateway('komoju_credit_card');
+
+    cy.goToStore();
+    cy.contains('Add to cart').click();
+    cy.contains('Cart').click();
+    cy.contains('Proceed to checkout').click();
+    cy.fillInAddress();
+
+    cy.get('#payment_method_komoju_konbini').click();
+    cy.get('#place_order').click();
+
+    cy.contains('Choose a Convenience Store').should('exist');
+    cy.location('pathname').should('include', '/sessions/');
+
+    cy.contains('Back to Merchant').click();
+    cy.get('#payment_method_komoju_credit_card').click();
+    cy.contains('Pay for order').click();
+
+    cy.contains('Enter Card Details').should('exist');
+    cy.location('pathname').should('include', '/sessions/');
+  })
 });


### PR DESCRIPTION
There are some stores that expire the checkout as soon as the user begins payment. Right now, this plugin returns the user to checkout when they click "return to merchant" on KOMOJU. For stores that expire the checkout, this behavior shows an error when the user tries to return to the store.

This PR changes the plugin behavior. Instead of returning to checkout, we now return to the pay-order page for the existing order (this is pretty subtle, honestly. there's barely any difference on the default development store).


https://user-images.githubusercontent.com/2793160/175858707-108d2dc0-6b34-4da9-a441-3fd5bcca615d.mp4



## To test

1. Start a payment through WooCommerce
2. Click "back to merchant" from the KOMOJU session page
3. You should be back on the store, but not the checkout. Your url should include "pay-order".