### PR TITLE
Consistent branding: KOMOJU instead of Komoju

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Always start the configuration by using the test mode secret key and do a few te
 To enable Debug click the 'Enable logging' box.
 
 
-### Configuring your Komoju account
+### Configuring your KOMOJU account
 
 To ensure that the WooCommerce plugin works correctly you will need to set up a webhook from your Komoju dashboard to the wordpress instance. To do this you will need to go to your [Webhook page on the Komoju dashboard](https://komoju.com/admin/webhooks) and click "New Webhook". If you don't know what the webhook URL should be you can check the admin page for this plugin on your wordpress instance to see the default address. The secret can be anything you want (as long as you remember it), but you must make sure the following events are ticked:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-*** Komoju gateway Changelog ***
+*** KOMOJU gateway Changelog ***
 
 2020.04.21
 * Update plugin to be compatible with WooCommerce v4

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- *Komoju Payment Gateway
+ * KOMOJU Payment Gateway
  *
  * Provides access to Japanese local payment methods.
  *
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
  *
  * @version     2.3.1
  *
- * @author      Komoju
+ * @author      KOMOJU
  */
 require_once dirname(__FILE__) . '/komoju-php/komoju-php/lib/komoju.php';
 
@@ -35,8 +35,8 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     {
         $this->id                   = $this->id ? $this->id : 'komoju';
         $this->has_fields           = gettype($this->has_fields) == 'boolean' ? $this->has_fields : true;
-        $this->method_title         = $this->method_title ? $this->method_title : __('Komoju', 'komoju-woocommerce');
-        $this->method_description   = __('Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.', 'komoju-woocommerce');
+        $this->method_title         = $this->method_title ? $this->method_title : __('KOMOJU', 'komoju-woocommerce');
+        $this->method_description   = __('Allows payments by KOMOJU, dedicated to Japanese online and offline payment gateways.', 'komoju-woocommerce');
         $this->debug                = 'yes' === $this->get_option_compat('debug_log', 'debug');
         $this->invoice_prefix       = $this->get_option_compat('invoice_prefix', 'invoice_prefix');
         $this->secretKey            = $this->get_option_compat('secret_key', 'secretKey');
@@ -368,7 +368,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
      */
     protected function default_title()
     {
-        return __('Komoju', 'komoju-woocommerce');
+        return __('KOMOJU', 'komoju-woocommerce');
     }
 
     public static function to_cents($total, $currency = '')

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  *
  * @version     2.3.1
  *
- * @author      Komoju
+ * @author      KOMOJU
  */
 require_once dirname(__FILE__) . '/komoju-php/komoju-php/lib/komoju.php';
 
@@ -21,7 +21,7 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
     public function __construct()
     {
         $this->id    = 'komoju_settings';
-        $this->label = __('Komoju', 'komoju-woocommerce');
+        $this->label = __('KOMOJU', 'komoju-woocommerce');
 
         add_action(
             'woocommerce_admin_field_komoju_payment_types',
@@ -371,7 +371,7 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
         $global_option = get_option('komoju_woocommerce_secret_key');
         if (!$global_option) {
             // This is for backwards compatibility. We used to have all settings saved under
-            // a single payment gateway called "Komoju". We've sinced moved to having this
+            // a single payment gateway called "KOMOJU". We've sinced moved to having this
             // global settings page, but want to continue supporting old setups.
             return WC_Gateway_Komoju::get_legacy_setting('secretKey');
         }

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -55,7 +55,7 @@ and click "Continue"
 16. Click "Save changes" at the bottom:
 ![Set currency](./images/Set_currency.png)
 
-## Setting up the Komoju WooCommerce plugin
+## Setting up the KOMOJU WooCommerce plugin
 
 1. On the WordPress admin page, click "Plugins" on the left side panel
 2. On the Plugins page click "Activate" under "WooCommerce Komoju Gateway"

--- a/docs/uploading_to_wordpress_store.md
+++ b/docs/uploading_to_wordpress_store.md
@@ -2,6 +2,17 @@
 
 This document details how to release a new version of the plugin on the WordPress store. This is intended for Komoju developers and requires access to the company's WordPress account.
 
+## The easy way
+
+We now use GitHub Actions to automate all of this. Unless you have an issue, you can ignore the rest of this document and simply run this command:
+
+```bash
+$ git tag v0.0.0 # Replace 0.0.0 with the version you want to upload
+$ git push --tags
+```
+
+That's it. You can check the result on the Actions tab in GitHub.
+
 ## Prerequisites
 
 Before you start, make sure to have the SVN cli tools installed. If you are on a Mac, then you can install them with Homebrew: `brew install svn`

--- a/includes/account-settings-komoju.php
+++ b/includes/account-settings-komoju.php
@@ -5,7 +5,7 @@ if (!defined('ABSPATH')) {
 }
 
 /*
- * Settings for the whole Komoju plugin
+ * Simple settings page with just sign-in button and payment methods
  */
 
 return [

--- a/includes/api-settings-komoju.php
+++ b/includes/api-settings-komoju.php
@@ -5,7 +5,7 @@ if (!defined('ABSPATH')) {
 }
 
 /*
- * Settings for the whole Komoju plugin
+ * Settings for the whole KOMOJU plugin
  */
 
 return [
@@ -18,14 +18,14 @@ return [
     [
         'id'          => 'komoju_woocommerce_secret_key',
         'placeholder' => 'sk_live_000000000000000000000000',
-        'title'       => __('Secret Key from Komoju', 'komoju-woocommerce'),
+        'title'       => __('Secret Key from KOMOJU', 'komoju-woocommerce'),
         'type'        => 'text',
         'default'     => WC_Gateway_Komoju::get_legacy_setting('secretKey'),
         'desc_tip'    => true,
     ],
     [
         'id'          => 'komoju_woocommerce_webhook_secret',
-        'placeholder' => __('Please enter your Komoju Webhook Secret Token', 'komoju-woocommerce'),
+        'placeholder' => __('Please enter your KOMOJU Webhook Secret Token', 'komoju-woocommerce'),
         'title'       => __('Webhook Secret Token', 'komoju-woocommerce'),
         'type'        => 'text',
         'default'     => WC_Gateway_Komoju::get_legacy_setting('webhookSecretToken'),
@@ -33,7 +33,7 @@ return [
     ],
     [
         'id'          => 'komoju_woocommerce_invoice_prefix',
-        'placeholder' => __('Please enter a prefix for your invoice numbers. If you use your Komoju account for multiple stores ensure this prefix is unique.', 'komoju-woocommerce'),
+        'placeholder' => __('Please enter a prefix for your invoice numbers. If you use your KOMOJU account for multiple stores ensure this prefix is unique.', 'komoju-woocommerce'),
         'title'       => __('Invoice Prefix', 'komoju-woocommerce'),
         'type'        => 'text',
         'default'     => WC_Gateway_Komoju::get_legacy_setting('invoice_prefix', 'WC-'),
@@ -41,7 +41,7 @@ return [
     ],
     [
         'id'          => 'komoju_woocommerce_debug_log',
-        'desc'        => sprintf(__('Log Komoju events inside <code>%s</code>', 'komoju-woocommerce'), wc_get_log_file_path('komoju')),
+        'desc'        => sprintf(__('Log KOMOJU events inside <code>%s</code>', 'komoju-woocommerce'), wc_get_log_file_path('komoju')),
         'desc_tip'    => true,
         'title'       => __('Debug Log', 'komoju-woocommerce'),
         'type'        => 'checkbox',

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -8,7 +8,7 @@ include_once 'class-wc-gateway-komoju-response.php';
 include_once 'class-wc-gateway-komoju-webhook-event.php';
 
 /**
- * Handles responses from Komoju IPN
+ * Handles responses from KOMOJU IPN
  */
 class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 {
@@ -34,7 +34,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     }
 
     /**
-     * Check for Komoju IPN or Session Response
+     * Check for KOMOJU IPN or Session Response
      */
     public function check_response()
     {
@@ -78,7 +78,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             do_action('valid-komoju-standard-ipn-request', $webhookEvent);
             exit;
         }
-        wp_die('Komoju IPN Request Failure', 'Komoju IPN', ['response' => 500]);
+        wp_die('KOMOJU IPN Request Failure', 'KOMOJU IPN', ['response' => 500]);
     }
 
     public function quick_setup($post)
@@ -137,7 +137,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     }
 
     /**
-     * Check Komoju IPN validity (hmac control)
+     * Check KOMOJU IPN validity (hmac control)
      *
      * @param string $requestBody the body of the request. Needed to correctly
      *                            calculate the HMAC for comparison.
@@ -153,7 +153,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
         $calcHmac = hash_hmac('sha256', $requestBody, $this->webhookSecretToken);
 
         if ($hmacHeader != $calcHmac) {
-            WC_Gateway_Komoju::log('hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...');
+            WC_Gateway_Komoju::log('hmac codes (sent by KOMOJU / recalculated) don\'t match. Exiting the process...');
 
             return false;
         }
@@ -174,7 +174,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             WC_Gateway_Komoju::log('Payment error: Currencies do not match (sent "' . $order->get_currency() . '" | returned "' . $currency . '")');
 
             // Put this order on-hold for manual checking
-            $order->update_status('on-hold', sprintf(__('Validation error: Komoju currencies do not match (code %s).', 'komoju-woocommerce'), $currency));
+            $order->update_status('on-hold', sprintf(__('Validation error: KOMOJU currencies do not match (code %s).', 'komoju-woocommerce'), $currency));
             exit;
         }
     }
@@ -191,7 +191,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             WC_Gateway_Komoju::log('Payment error: Amounts do not match (total: ' . $amount . ') for order #' . $order->get_id() . '(' . $order->get_total() . ')');
 
             // Put this order on-hold for manual checking
-            $order->update_status('on-hold', sprintf(__('Validation error: Komoju amounts do not match (total %s).', 'komoju-woocommerce'), $amount));
+            $order->update_status('on-hold', sprintf(__('Validation error: KOMOJU amounts do not match (total %s).', 'komoju-woocommerce'), $amount));
             exit;
         }
     }

--- a/includes/class-wc-gateway-komoju-request.php
+++ b/includes/class-wc-gateway-komoju-request.php
@@ -5,12 +5,12 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Generates requests to send to Komoju
+ * Generates requests to send to KOMOJU
  */
 class WC_Gateway_Komoju_Request
 {
     /**
-     * Stores line items to send to Komoju
+     * Stores line items to send to KOMOJU
      *
      * @var array
      */
@@ -36,7 +36,7 @@ class WC_Gateway_Komoju_Request
     }
 
     /**
-     * Get the Komoju request URL for an order
+     * Get the KOMOJU request URL for an order
      *
      * @param WC_Order $order
      *
@@ -50,7 +50,7 @@ class WC_Gateway_Komoju_Request
     }
 
     /**
-     * Get Komoju Args for passing to Komoju hosted page
+     * Get KOMOJU Args for passing to KOMOJU hosted page
      *
      * @param WC_Order $order
      * @param string $method the method of payment the user has selected, ie credit-card

--- a/includes/class-wc-gateway-komoju-response.php
+++ b/includes/class-wc-gateway-komoju-response.php
@@ -7,10 +7,10 @@ if (!defined('ABSPATH')) {
 abstract class WC_Gateway_Komoju_Response
 {
     /**
-     * Get the order from the Komoju 'transaction' variable
+     * Get the order from the KOMOJU 'transaction' variable
      *
      * @param WC_Gateway_Komoju_Webhook_Event $webhookEvent Webhook event data
-     * @param string $invoice_prefix set as an option in Komoju plugin dashboard
+     * @param string $invoice_prefix set as an option in KOMOJU plugin dashboard
      *
      * @return bool|WC_Order object
      */
@@ -40,7 +40,7 @@ abstract class WC_Gateway_Komoju_Response
      * Get an order from a payment associated with a KOMOJU session
      *
      * @param string $session_id
-     * @param string $invoice_prefix set as an option in Komoju plugin dashboard
+     * @param string $invoice_prefix set as an option in KOMOJU plugin dashboard
      */
     protected function get_order_from_komoju_session($session, $invoice_prefix)
     {

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -19,7 +19,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
         $this->payment_method = $payment_method;
         $this->id             = 'komoju_' . $slug;
         $this->has_fields     = false;
-        $this->method_title   = __('Komoju', 'komoju-woocommerce') . ' - ' . $this->default_title();
+        $this->method_title   = __('KOMOJU', 'komoju-woocommerce') . ' - ' . $this->default_title();
 
         if ($this->get_option('showIcon') == 'yes') {
             $this->icon = "https://komoju.com/payment_methods/$slug.svg";

--- a/includes/class-wc-gateway-komoju-webhook-event.php
+++ b/includes/class-wc-gateway-komoju-webhook-event.php
@@ -23,8 +23,8 @@ class WC_Gateway_Komoju_Webhook_Event
         $this->requestJson = json_decode($requestBody, true);
 
         if (!empty(json_last_error())) {
-            $errorMsg = 'Komoju IPN Request JSON Decoding Failure. Error: ' . json_last_error_msg();
-            wp_die($errorMsg, 'Komoju IPN', ['response' => 400]);
+            $errorMsg = 'KOMOJU IPN Request JSON Decoding Failure. Error: ' . json_last_error_msg();
+            wp_die($errorMsg, 'KOMOJU IPN', ['response' => 400]);
         }
     }
 

--- a/includes/gateway-settings-komoju.php
+++ b/includes/gateway-settings-komoju.php
@@ -5,14 +5,14 @@ if (!defined('ABSPATH')) {
 }
 
 /*
- * Gateway-specific Settings for Komoju
+ * Gateway-specific Settings for KOMOJU
  */
 
 return [
     'enabled' => [
         'title'   => __('Enable/Disable', 'komoju-woocommerce'),
         'type'    => 'checkbox',
-        'label'   => __('Enable Komoju', 'komoju-woocommerce'),
+        'label'   => __('Enable KOMOJU', 'komoju-woocommerce'),
         'default' => 'no',
     ],
     'showIcon' => [

--- a/languages/komoju-woocommerce-ja.po
+++ b/languages/komoju-woocommerce-ja.po
@@ -16,15 +16,15 @@ msgstr ""
 #: class-wc-gateway-komoju.php:369 class-wc-settings-page-komoju.php:24
 #: includes/class-wc-gateway-komoju-single-slug.php:22
 #: includes/settings-komoju.php:21
-msgid "Komoju"
+msgid "KOMOJU"
 msgstr ""
 
 #: class-wc-gateway-komoju.php:37
 msgid ""
-"Allows payments by Komoju, dedicated to Japanese online and offline payment "
+"Allows payments by KOMOJU, dedicated to Japanese online and offline payment "
 "gateways."
 msgstr ""
-"Komoju は日本独自のオンラインと オフラインの決済を提供するゲートウェイです。"
+"KOMOJU は日本独自のオンラインと オフラインの決済を提供するゲートウェイです。"
 
 #: class-wc-gateway-komoju.php:100 class-wc-gateway-komoju.php:102
 msgid "Gateway Disabled"
@@ -32,8 +32,8 @@ msgstr "ゲートウェイ無効"
 
 #: class-wc-gateway-komoju.php:100 class-wc-gateway-komoju.php:102
 #: class-wc-gateway-komoju.php:109
-msgid "Komoju does not support your store currency."
-msgstr "Komoju はあなたのストアの通貨をサポートしていません"
+msgid "KOMOJU does not support your store currency."
+msgstr "KOMOJU はあなたのストアの通貨をサポートしていません"
 
 #: class-wc-gateway-komoju.php:152 class-wc-gateway-komoju.php:154
 #: class-wc-gateway-komoju.php:270
@@ -80,14 +80,14 @@ msgstr "初期化"
 #: includes/class-wc-gateway-komoju-ipn-handler.php:108
 #: includes/class-wc-gateway-komoju-ipn-handler.php:111
 #, php-format
-msgid "Validation error: Komoju currencies do not match (code %s)."
+msgid "Validation error: KOMOJU currencies do not match (code %s)."
 msgstr "エラー: 通貨が不正です (code %s)。"
 
 #: includes/class-wc-gateway-komoju-ipn-handler.php:108
 #: includes/class-wc-gateway-komoju-ipn-handler.php:123
 #: includes/class-wc-gateway-komoju-ipn-handler.php:126
 #, php-format
-msgid "Validation error: Komoju amounts do not match (total %s)."
+msgid "Validation error: KOMOJU amounts do not match (total %s)."
 msgstr "エラー: 金額が不正です (total %s)。"
 
 #: includes/class-wc-gateway-komoju-ipn-handler.php:128
@@ -123,8 +123,8 @@ msgid "Enable/Disable"
 msgstr "有効 / 無効"
 
 #: includes/settings-komoju.php:14
-msgid "Enable Komoju"
-msgstr "有効 Komoju"
+msgid "Enable KOMOJU"
+msgstr "有効 KOMOJU"
 
 #: includes/settings-komoju.php:18
 msgid "Title"
@@ -142,24 +142,24 @@ msgid ""
 msgstr "Webhook のデフォルト URL は %s です。"
 
 #: includes/settings-komoju.php:74 includes/settings-komoju.php:75
-msgid "Komoju merchant ID"
-msgstr "Komoju マーチャントID"
+msgid "KOMOJU merchant ID"
+msgstr "KOMOJU マーチャントID"
 
 #: includes/settings-komoju.php:76 includes/settings-komoju.php:77
-msgid "Please enter your Komoju account ID."
-msgstr "Komoju のアカウントID を入力してください"
+msgid "Please enter your KOMOJU account ID."
+msgstr "KOMOJU のアカウントID を入力してください"
 
 #: includes/global-settings-komoju.php:21
 msgid "Payment Gateways"
 msgstr "支払い方法"
 
 #: includes/settings-komoju.php:81 includes/settings-komoju.php:82
-msgid "Secret Key from Komoju"
-msgstr "Komoju 非公開鍵"
+msgid "Secret Key from KOMOJU"
+msgstr "KOMOJU 非公開鍵"
 
 #: includes/settings-komoju.php:83 includes/settings-komoju.php:84
-msgid "Please enter your Komoju secret key."
-msgstr "Komoju の非公開鍵を入力してください"
+msgid "Please enter your KOMOJU secret key."
+msgstr "KOMOJU の非公開鍵を入力してください"
 
 #: includes/settings-komoju.php:88
 msgid "Callback Url"
@@ -178,16 +178,16 @@ msgstr ""
 "コールバックURLを指定 (もし分からない場合は空欄でも可能) 。デフォルトURL  %s"
 
 #: includes/settings-komoju.php:91
-msgid "Please enter your Komoju Webhook Secret Token"
-msgstr "Komoju のシークレットトークンを入力してください"
+msgid "Please enter your KOMOJU Webhook Secret Token"
+msgstr "KOMOJU のシークレットトークンを入力してください"
 
 #: includes/settings-komoju.php:94
-msgid "Komoju Sandbox"
-msgstr "Komoju サンドボックス"
+msgid "KOMOJU Sandbox"
+msgstr "KOMOJU サンドボックス"
 
 #: includes/settings-komoju.php:96
-msgid "Enable Komoju sandbox"
-msgstr "Komoju サンドボックスを有効"
+msgid "Enable KOMOJU sandbox"
+msgstr "KOMOJU サンドボックスを有効"
 
 #: includes/settings-komoju.php:96 includes/settings-komoju.php:101
 msgid "Invoice Prefix"
@@ -195,17 +195,17 @@ msgstr "請求書の先頭文字"
 
 #: includes/settings-komoju.php:98 includes/settings-komoju.php:103
 msgid ""
-"Please enter a prefix for your invoice numbers. If you use your Komoju "
+"Please enter a prefix for your invoice numbers. If you use your KOMOJU "
 "account for multiple stores ensure this prefix is unique."
 msgstr "請求書の先頭文字を入力してください。"
 
 #: includes/settings-komoju.php:98
 #, php-format
 msgid ""
-"When checked, your Komoju sandbox will be used in order to test payments. "
+"When checked, your KOMOJU sandbox will be used in order to test payments. "
 "Sign up for a developer account <a href=\"%s\">here</a>."
 msgstr ""
-"支払った際、Komoju サンドボックス上でテストの決済が実行されます。 開発用アカ"
+"支払った際、KOMOJU サンドボックス上でテストの決済が実行されます。 開発用アカ"
 "ウント登録は<a href=\"%s\">こちら</a> 。"
 
 #: includes/settings-komoju.php:103 includes/settings-komoju.php:108
@@ -230,8 +230,8 @@ msgstr "Staging token"
 
 #: includes/settings-komoju.php:107 includes/settings-komoju.php:112
 #, php-format
-msgid "Log Komoju events inside <code>%s</code>"
-msgstr "Komoju のイベントログ <code>%s</code>"
+msgid "Log KOMOJU events inside <code>%s</code>"
+msgstr "KOMOJU のイベントログ <code>%s</code>"
 
 #: includes/settings-komoju.php
 #, php-format

--- a/languages/komoju-woocommerce.pot
+++ b/languages/komoju-woocommerce.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: komoju-woocommerce\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-20 22:30+0900\n"
+"POT-Creation-Date: 2022-06-27 14:29+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,17 +18,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: class-wc-gateway-komoju.php:36 class-wc-gateway-komoju.php:38
-#: class-wc-gateway-komoju.php:369 class-wc-gateway-komoju.php:372
-#: class-wc-settings-page-komoju.php:24
+#: class-wc-gateway-komoju.php:369 class-wc-gateway-komoju.php:371
+#: class-wc-gateway-komoju.php:372 class-wc-settings-page-komoju.php:24
 #: includes/class-wc-gateway-komoju-single-slug.php:22
 #: includes/settings-komoju.php:21
-msgid "Komoju"
+msgid "KOMOJU"
 msgstr ""
 
 #: class-wc-gateway-komoju.php:37 class-wc-gateway-komoju.php:39
 msgid ""
-"Allows payments by Komoju, dedicated to Japanese online and offline payment "
+"Allows payments by KOMOJU, dedicated to Japanese online and offline payment "
 "gateways."
+msgstr ""
+
+#: class-wc-gateway-komoju.php:87
+msgid "View payment on KOMOJU"
 msgstr ""
 
 #: class-wc-gateway-komoju.php:100 class-wc-gateway-komoju.php:102
@@ -38,16 +42,17 @@ msgstr ""
 
 #: class-wc-gateway-komoju.php:100 class-wc-gateway-komoju.php:102
 #: class-wc-gateway-komoju.php:109
-msgid "Komoju does not support your store currency."
+msgid "KOMOJU does not support your store currency."
 msgstr ""
 
 #: class-wc-gateway-komoju.php:152 class-wc-gateway-komoju.php:154
-#: class-wc-gateway-komoju.php:270 class-wc-gateway-komoju.php:273
+#: class-wc-gateway-komoju.php:270 class-wc-gateway-komoju.php:272
+#: class-wc-gateway-komoju.php:273
 msgid "Method of payment:"
 msgstr ""
 
 #: class-wc-gateway-komoju.php:190 class-wc-gateway-komoju.php:295
-#: class-wc-gateway-komoju.php:298
+#: class-wc-gateway-komoju.php:297 class-wc-gateway-komoju.php:298
 #: includes/class-wc-gateway-komoju-ipn-handler.php:55
 msgid ""
 "Encountered an issue communicating with KOMOJU. Please wait a moment and try "
@@ -55,7 +60,7 @@ msgid ""
 msgstr ""
 
 #: class-wc-gateway-komoju.php:191 class-wc-gateway-komoju.php:320
-#: class-wc-gateway-komoju.php:323
+#: class-wc-gateway-komoju.php:322 class-wc-gateway-komoju.php:323
 msgid "Please select a payment method (how you want to pay)"
 msgstr ""
 
@@ -129,14 +134,13 @@ msgid ""
 "should be."
 msgstr ""
 
-#: includes/api-settings-komoju.php:21 includes/global-settings-komoju.php:26
-#: includes/settings-komoju.php:81 includes/settings-komoju.php:82
-msgid "Secret Key from Komoju"
+#: includes/api-settings-komoju.php:21
+msgid "Secret Key from KOMOJU"
 msgstr ""
 
 #: includes/api-settings-komoju.php:28 includes/global-settings-komoju.php:33
 #: includes/settings-komoju.php:91
-msgid "Please enter your Komoju Webhook Secret Token"
+msgid "Please enter your KOMOJU Webhook Secret Token"
 msgstr ""
 
 #: includes/api-settings-komoju.php:29 includes/global-settings-komoju.php:34
@@ -144,10 +148,9 @@ msgstr ""
 msgid "Webhook Secret Token"
 msgstr ""
 
-#: includes/api-settings-komoju.php:36 includes/global-settings-komoju.php:41
-#: includes/settings-komoju.php:98 includes/settings-komoju.php:103
+#: includes/api-settings-komoju.php:36
 msgid ""
-"Please enter a prefix for your invoice numbers. If you use your Komoju "
+"Please enter a prefix for your invoice numbers. If you use your KOMOJU "
 "account for multiple stores ensure this prefix is unique."
 msgstr ""
 
@@ -156,10 +159,9 @@ msgstr ""
 msgid "Invoice Prefix"
 msgstr ""
 
-#: includes/api-settings-komoju.php:44 includes/global-settings-komoju.php:49
-#: includes/settings-komoju.php:107 includes/settings-komoju.php:112
+#: includes/api-settings-komoju.php:44
 #, php-format
-msgid "Log Komoju events inside <code>%s</code>"
+msgid "Log KOMOJU events inside <code>%s</code>"
 msgstr ""
 
 #: includes/api-settings-komoju.php:46 includes/global-settings-komoju.php:51
@@ -190,7 +192,7 @@ msgstr ""
 #: includes/class-wc-gateway-komoju-ipn-handler.php:151
 #: includes/class-wc-gateway-komoju-ipn-handler.php:177
 #, php-format
-msgid "Validation error: Komoju currencies do not match (code %s)."
+msgid "Validation error: KOMOJU currencies do not match (code %s)."
 msgstr ""
 
 #: includes/class-wc-gateway-komoju-ipn-handler.php:108
@@ -199,7 +201,7 @@ msgstr ""
 #: includes/class-wc-gateway-komoju-ipn-handler.php:168
 #: includes/class-wc-gateway-komoju-ipn-handler.php:194
 #, php-format
-msgid "Validation error: Komoju amounts do not match (total %s)."
+msgid "Validation error: KOMOJU amounts do not match (total %s)."
 msgstr ""
 
 #: includes/class-wc-gateway-komoju-ipn-handler.php:128
@@ -245,37 +247,49 @@ msgid "Enable/Disable"
 msgstr ""
 
 #: includes/gateway-settings-komoju.php:15 includes/settings-komoju.php:14
-msgid "Enable Komoju"
+msgid "Enable KOMOJU"
 msgstr ""
 
-#: includes/gateway-settings-komoju.php:19 includes/settings-komoju.php:18
+#: includes/gateway-settings-komoju.php:19
+msgid "Icon"
+msgstr ""
+
+#: includes/gateway-settings-komoju.php:19
+#: includes/gateway-settings-komoju.php:25 includes/settings-komoju.php:18
 msgid "Title"
 msgstr ""
 
-#: includes/gateway-settings-komoju.php:21 includes/settings-komoju.php:20
+#: includes/gateway-settings-komoju.php:20
+msgid "Show icon on checkout"
+msgstr ""
+
+#: includes/gateway-settings-komoju.php:21
+#: includes/gateway-settings-komoju.php:27 includes/settings-komoju.php:20
 msgid "This controls the title which the user sees during checkout."
 msgstr ""
 
 #: includes/gateway-settings-komoju.php:26
+#: includes/gateway-settings-komoju.php:32
 msgid "Use on-hold status for pending payments"
 msgstr ""
 
 #: includes/gateway-settings-komoju.php:28
+#: includes/gateway-settings-komoju.php:34
 msgid ""
 "Use 'on-hold' status for payments that are authorized on komoju but awaiting "
 "capture. If not selected, 'payment pending' status will be used."
 msgstr ""
 
 #: includes/settings-komoju.php:74 includes/settings-komoju.php:75
-msgid "Komoju merchant ID"
+msgid "KOMOJU merchant ID"
 msgstr ""
 
 #: includes/settings-komoju.php:76 includes/settings-komoju.php:77
-msgid "Please enter your Komoju account ID."
+msgid "Please enter your KOMOJU account ID."
 msgstr ""
 
 #: includes/settings-komoju.php:83 includes/settings-komoju.php:84
-msgid "Please enter your Komoju secret key."
+msgid "Please enter your KOMOJU secret key."
 msgstr ""
 
 #: includes/settings-komoju.php:88
@@ -290,16 +304,16 @@ msgid ""
 msgstr ""
 
 #: includes/settings-komoju.php:94
-msgid "Komoju Sandbox"
+msgid "KOMOJU Sandbox"
 msgstr ""
 
 #: includes/settings-komoju.php:96
-msgid "Enable Komoju sandbox"
+msgid "Enable KOMOJU sandbox"
 msgstr ""
 
 #: includes/settings-komoju.php:98
 #, php-format
 msgid ""
-"When checked, your Komoju sandbox will be used in order to test payments. "
+"When checked, your KOMOJU sandbox will be used in order to test payments. "
 "Sign up for a developer account <a href=\"%s\">here</a>."
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -126,7 +126,7 @@ Always start the configuration by using the test mode secret key and do a few te
 
 To enable Debug click the 'Enable logging' box.
 
-= Configuring your Komoju account =
+= Configuring your KOMOJU account =
 To ensure that the WooCommerce plugin works correctly you will need to set up a webhook from your KOMOJU dashboard to the wordpress instance. To do this you will need to go to your [Webhook page on the Komoju dashboard](https://komoju.com/admin/webhooks) and click "New Webhook". If you don't know what the webhook URL should be you can check the admin page for this plugin on your wordpress instance to see the default address. The secret can be anything you want (as long as you remember it), but you must make sure the following events are ticked:
 
 - payment.authorized

--- a/tests/cypress/integration/admin.spec.js
+++ b/tests/cypress/integration/admin.spec.js
@@ -14,16 +14,16 @@ describe('KOMOJU for WooCommerce: Admin', () => {
     cy.setupKomoju(['konbini', 'credit_card']);
     cy.contains('Payments').click();
 
-    cy.get('.form-table').should('include.text', 'Komoju - Konbini');
-    cy.get('.form-table').should('include.text', 'Komoju - Credit Card');
+    cy.get('.form-table').should('include.text', 'KOMOJU - Konbini');
+    cy.get('.form-table').should('include.text', 'KOMOJU - Credit Card');
 
     cy.setupKomoju(['docomo', 'softbank']);
     cy.contains('Payments').click();
 
-    cy.get('.form-table').should('not.include.text', 'Komoju - Konbini');
-    cy.get('.form-table').should('not.include.text', 'Komoju - Credit Card');
-    cy.get('.form-table').should('include.text',     'Komoju - SoftBank');
-    cy.get('.form-table').should('include.text',     'Komoju - docomo');
+    cy.get('.form-table').should('not.include.text', 'KOMOJU - Konbini');
+    cy.get('.form-table').should('not.include.text', 'KOMOJU - Credit Card');
+    cy.get('.form-table').should('include.text',     'KOMOJU - SoftBank');
+    cy.get('.form-table').should('include.text',     'KOMOJU - docomo');
   })
 
   it('lets me change the KOMOJU endpoint', () => {

--- a/tests/cypress/integration/checkout.spec.js
+++ b/tests/cypress/integration/checkout.spec.js
@@ -16,7 +16,7 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.contains('Proceed to checkout').click();
     cy.fillInAddress();
 
-    cy.contains('Komoju').click();
+    cy.contains('KOMOJU').click();
     cy.get('.blockUI,.blockOverlay').should('not.exist');
 
     // This waits for the "expanding box" animation to finish

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Komoju Payment Gateway
+ * WooCommerce KOMOJU Payment Gateway
  * Uninstall - removes all options from DB when user deletes the plugin via WordPress backend.
  *
  * @since 1.0


### PR DESCRIPTION
Awhile back (but after this plugin's debut), we decided to always use "KOMOJU" instead of "Komoju" when writing about the product.

This PR replaces all instances of "Komoju" with "KOMOJU".

![image](https://user-images.githubusercontent.com/2793160/175867537-da38d5af-4408-4f17-a3c2-2e02fe97ea98.png)
