### PR TITLE
Remove payment method selector from "KOMOJU" payment method

### DIFF
--- a/tests/cypress/integration/checkout.spec.js
+++ b/tests/cypress/integration/checkout.spec.js
@@ -19,15 +19,9 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.contains('Komoju').click();
     cy.get('.blockUI,.blockOverlay').should('not.exist');
 
-    // This waits for the "expanding box" animation to finish
-    cy.get('.payment_method_komoju[style]').should('not.exist');
-
-    cy.get('#komoju-cc-form').contains('Pay Easy').click();
-    cy.get('.blockUI,.blockOverlay').should('not.exist');
-
     cy.get('#place_order').click();
-    cy.contains('Enter Account Holder Details').should('exist');
     cy.location('pathname').should('include', '/sessions/');
+    cy.contains('Select Payment Method').should('exist');
   })
 
   it('lets me make a payment using the specialized konbini gateway', () => {
@@ -41,8 +35,6 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.fillInAddress();
 
     cy.get('#payment_method_komoju_konbini').click();
-    cy.get('.payment_method_komoju[style="display: none;"]').should('exist');
-    cy.get('.blockUI,.blockOverlay').should('not.exist');
     cy.get('#place_order').click();
 
     cy.contains('Choose a Convenience Store').should('exist');


### PR DESCRIPTION
We recently added [support for assigning one WooCommerce payment method per KOMOJU payment method](https://github.com/degica/komoju-woocommerce/pull/53). That feature kind of makes the "KOMOJU" payment method obsolete, but just in case people want to use it, this improves the UX a little bit by removing the payment method radio buttons in favor of using our native Session payment method selector.