### PR TITLE
Fix locales with country code

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -305,14 +305,15 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
 
     public static function get_locale_or_fallback()
     {
-        $fallback_locale   = 'en';
-        $supported_locales = ['ja', 'en', 'ko'];
-        $page_locale       = get_locale();
+        $fallback_lang   = 'en';
+        $supported_langs = ['ja', 'en', 'ko'];
+        $page_locale     = get_locale();
+        $lang            = is_string($page_locale) ? substr($page_locale, 0, 2) : $fallback_lang;
 
-        if (in_array($page_locale, $supported_locales)) {
-            return $page_locale;
+        if (in_array($lang, $supported_langs)) {
+            return $lang;
         } else {
-            return $fallback_locale;
+            return $fallback_lang;
         }
     }
 

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     2.4.0
+ * @version     2.4.1
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Settings_Page_Komoju
  * @extends     WC_Settings_Page
  *
- * @version     2.4.0
+ * @version     2.4.1
  *
  * @author      Komoju
  */

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 2.4.0
+Version: 2.4.1
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -205,3 +205,6 @@ Refunding KOMOJU payments through the WooCommerce dashboard is now supported.
 Added a link to the KOMOJU admin page for orders paid with KOMOJU.
 Clicking "back to merchant" on KOMOJU will now take you to the pay-order page instead of checkout.
 Can now toggle whether or not KOMOJU payment method icons appear.
+
+= 2.4.1 =
+Fixed bug where plugin would ignore locale strings that include a country code.


### PR DESCRIPTION
Locale strings often look like `en_US` or `ko_KR`. Before this PR, the plugin would not properly treat `ko_KR` as `ko`.