### PR TITLE
Make quick setup work on shops with a scoped root path

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     2.6.2
+ * @version     2.6.3
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Settings_Page_Komoju
  * @extends     WC_Settings_Page
  *
- * @version     2.6.2
+ * @version     2.6.3
  *
  * @author      Komoju
  */

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -100,7 +100,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
         update_option('komoju_woocommerce_just_connected_merchant_name', $post['merchant_name']);
 
-        wp_redirect(admin_url() . '?page=wc-settings&tab=komoju_settings');
+        wp_redirect(admin_url() . 'admin.php?page=wc-settings&tab=komoju_settings');
     }
 
     /**

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -100,7 +100,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
         update_option('komoju_woocommerce_just_connected_merchant_name', $post['merchant_name']);
 
-        wp_redirect('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings');
+        wp_redirect(admin_url() . '?page=wc-settings&tab=komoju_settings');
     }
 
     /**

--- a/index.php
+++ b/index.php
@@ -12,22 +12,17 @@ add_action('plugins_loaded', 'woocommerce_komoju_init', 0);
 
 function woocommerce_komoju_init()
 {
-    if (!class_exists('WC_Payment_Gateway')) {
-        return;
-    }
-
     /*
      * Localisation
      */
     load_plugin_textdomain('komoju-woocommerce', false, dirname(plugin_basename(__FILE__)) . '/languages');
-
-    require_once 'class-wc-gateway-komoju.php';
 
     /**
      * Add the Gateway to WooCommerce
      **/
     function woocommerce_add_komoju_gateway($methods)
     {
+        require_once 'class-wc-gateway-komoju.php';
         require_once 'includes/class-wc-gateway-komoju-single-slug.php';
         $methods[] = new WC_Gateway_Komoju();
 
@@ -46,6 +41,7 @@ function woocommerce_komoju_init()
      **/
     function woocommerce_add_komoju_settings_page($settings)
     {
+        require_once 'class-wc-gateway-komoju.php';
         require_once 'class-wc-settings-page-komoju.php';
         $settings[] = new WC_Settings_Page_Komoju();
 

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 2.6.2
+Version: 2.6.3
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -220,3 +220,6 @@ Fix webhooks with currencies that use cents.
 
 = 2.6.2 =
 Swap first/last name order when sending to KOMOJU (KOMOJU expects given before family).
+
+= 2.6.3 =
+Fix problem where komoju payment gateways were not added in some situations.

--- a/readme.txt
+++ b/readme.txt
@@ -222,4 +222,5 @@ Fix webhooks with currencies that use cents.
 Swap first/last name order when sending to KOMOJU (KOMOJU expects given before family).
 
 = 2.6.3 =
-Fix problem where komoju payment gateways were not added in some situations.
+Make sure payment gateways are always present when plugins are loaded.
+Fix problem where quick setup failed on sites with a path prefix.


### PR DESCRIPTION
We were assuming that the admin is always located at /wp-admin/admin.php. This PR fixes that, allowing the quick setup feature to work regardless of where admin.php is located.