### PR TITLE
Fix amount validation in dynamic currency scenarios

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     2.7.0
+ * @version     2.7.1
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Settings_Page_Komoju
  * @extends     WC_Settings_Page
  *
- * @version     2.7.0
+ * @version     2.7.1
  *
  * @author      Komoju
  */

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -194,7 +194,13 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             exit;
         }
 
-        $this->validate_amount($order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee());
+        if ($webhookEvent->currency() != $order->get_currency()) {
+            $session = $this->get_session($webhookEvent->session_id());
+            $this->validate_amount($order, $session->amount);
+        } else {
+            $this->validate_amount($order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee());
+        }
+
         $this->save_komoju_meta_data($order, $webhookEvent);
 
         if ('captured' === $webhookEvent->status()) {

--- a/includes/class-wc-gateway-komoju-webhook-event.php
+++ b/includes/class-wc-gateway-komoju-webhook-event.php
@@ -135,6 +135,16 @@ class WC_Gateway_Komoju_Webhook_Event
     }
 
     /**
+     * A getter to retrieve the session ID from the webhook event
+     *
+     * @return string
+     */
+    public function session_id()
+    {
+        return $this->data()['session'];
+    }
+
+    /**
      * A get to retrieve the amount refunded from the webhook event. This will
      * only be sent on payment.refunded events
      *

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 2.7.0
+Version: 2.7.1
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -233,3 +233,6 @@ Remove additional lingering currency check code.
 
 = 2.7.0 =
 Change credit card icon to show brands.
+
+= 2.7.1 =
+Make DCC payments validate order amount against session instead of payment.


### PR DESCRIPTION
We need to validate the order amount on capture to make sure the order contents didn't change before payment was completed.

This is a little tricker when dynamic currency conversion is being used, since the payment amount will almost certainly not be the same as the order amount. In such cases, we can check against the session amount instead of the payment amount.