### PR TITLE
Use immutable WC order ID for KOMOJU sessions

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -197,7 +197,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             ],
             'line_items' => $line_items,
             'metadata'   => [
-                'woocommerce_order_id' => $order->get_order_number(),
+                'woocommerce_order_id' => $order->get_id(),
             ],
         ];
         $remove_nulls = function ($v) { return !is_null($v); };


### PR DESCRIPTION
WC_Order::get_order_number by default uses the order ID, but seems that it can be changed.

* https://wp-kama.com/plugin/woocommerce/function/WC_Data::get_id