### PR TITLE
Fix for multiple payments.

### DIFF
--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -224,6 +224,12 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_cancelled($order, $webhookEvent)
     {
+        $external_order_num = $order->get_transaction_id();
+        if (!empty($external_order_num) && $external_order_num != $webhookEvent->external_order_num()) {
+            WC_Gateway_Komoju::log('Aborting, External order num #' . $external_order_num . ' is multiple payment order.');
+            exit;
+        }
+
         $order->update_status('cancelled', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
     }
 

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -224,9 +224,10 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_cancelled($order, $webhookEvent)
     {
-        $external_order_num = $order->get_transaction_id();
-        if (!empty($external_order_num) && $external_order_num != $webhookEvent->external_order_num()) {
-            WC_Gateway_Komoju::log('Aborting, External order num #' . $external_order_num . ' is multiple payment order.');
+        $transaction_id = $order->get_transaction_id();
+        $external_order_num = $webhookEvent->external_order_num();
+        if (!empty($transaction_id) && $transaction_id != $webhookEvent->external_order_num()) {
+            WC_Gateway_Komoju::log('Aborting, transaction_id: ' . $transaction_id . ' and external_order_num: ' . $external_order_num . ' do not match.');
             exit;
         }
 

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -224,7 +224,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_cancelled($order, $webhookEvent)
     {
-        $transaction_id = $order->get_transaction_id();
+        $transaction_id     = $order->get_transaction_id();
         $external_order_num = $webhookEvent->external_order_num();
         if (!empty($transaction_id) && $transaction_id != $webhookEvent->external_order_num()) {
             WC_Gateway_Komoju::log('Aborting, transaction_id: ' . $transaction_id . ' and external_order_num: ' . $external_order_num . ' do not match.');


### PR DESCRIPTION
## Context

Fixes (https://github.com/degica/komoju-woocommerce/issues/83)

Fixed this issue.
> A merchant asked us about some orders and told us cancellation webhook event was received for the Woocommerce order after a successful capture. It turns out such orders have multiple payments. So a problem happens when a payment is captured for an order but another payment for the same order gets cancelled, which cancels the order when it shouldn't.

Fixed to abort cancellation process if order's transaction_id does not match with webhookEvent.
(The transaction_id of order is set when the payment is captured.)
https://github.com/degica/komoju-woocommerce/blob/master/includes/class-wc-gateway-komoju-ipn-handler.php#L208

## How to test
There are many steps to the test, so we have included a video. Please refer to it.

1. I'd recommend running the cypress tests to do all the wordpress/woocommerce/product setup, but you can also do manually via https://github.com/degica/komoju-woocommerce/blob/master/docs/dev_setup.md
2. Visit http://localhost:8000/?post_type=product
3. Add a product to cart then checkout.
4. Pay by one of the payment methods.
5. Visit `My account/Orders` page.
6. Click on `Pay` for the order you just placed.
7. Pay by one of the payment methods.
8. Go to one payment details. (komoju.com/admin/payments/XXXXXX)
9. Click on `Capture Payment` .
10. Go to another payment details. (komoju.com/admin/payments/XXXXXX)
11. Click on `Cancel` .
12. Make sure it has not been cancelled. (http://localhost:8000/wp-admin/edit.php?post_type=shop_order)

https://user-images.githubusercontent.com/30614258/222359677-25a262e6-5dca-445a-b8e1-2fbe0bfad77b.mov

