### PR TITLE
Redirect merchant to old (stable) URL for payments link

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -80,7 +80,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             return;
         }
 
-        $url = $this->komoju_api->endpoint . '/merchant/payments/' . $payment_id; ?>
+        $url = $this->komoju_api->endpoint . '/admin/payments/' . $payment_id; ?>
         <p>
             <a href="<?php echo esc_attr($url); ?>">
                 <?php echo __('View payment on KOMOJU', 'komoju-woocommerce'); ?>


### PR DESCRIPTION
The link currently points to the new admin pages we're building, but while the new dashboard is in beta we should redirect all users to the existing, stable implementation by default.