### PR TITLE
Fix failing tests

### DIFF
--- a/tests/cypress/e2e/checkout.cy.js
+++ b/tests/cypress/e2e/checkout.cy.js
@@ -24,7 +24,7 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.wait(1500);
     cy.get('#place_order').click();
     cy.location('pathname').should('include', '/sessions/');
-    cy.contains('Select Payment Method').should('exist');
+    cy.contains('Select Payment Method', {matchCase: false }).should('exist');
   })
 
   it('lets me make a payment using the specialized konbini gateway', () => {
@@ -49,7 +49,7 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.get('#place_order').click();
 
     // It can take a crazy long time to reach KOMOJU from here...
-    cy.contains('How to make a payment at Family Mart', { timeout: 20000 }).should('be.visible');
+    cy.contains('How to make a payment at Family Mart', { matchCase: false, timeout: 20000 }).should('be.visible');
     cy.location('pathname').should('include', '/sessions/');
     cy.contains('Return to').click();
     cy.contains('Thank you. Your order has been received.').should('be.visible');
@@ -97,7 +97,7 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.wait(2000);
     cy.get('#place_order').click();
     cy.wait(2000);
-    cy.contains('WebMoney Details').should('be.visible');
+    cy.contains('WebMoney Details', { matchCase: false }).should('be.visible');
     cy.location('pathname').should('include', '/sessions/');
   });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -103,8 +103,9 @@ Cypress.Commands.add('installKomoju', () => {
 
 Cypress.Commands.add('setupKomoju', (
   paymentTypes = [],
-  secretKey = 'degica-mart-test',
-  publishableKey = 'pk_d6acce1f17e4468c30833b666d9006f100e9fa8c'
+  // fake-mart
+  secretKey = 'sk_27dbcf7af57ad9088b8c95792c6f24d2398e771c',
+  publishableKey = 'pk_c05e982fa446efa4ff740d1f055a45a4e0c21d5f'
 ) => {
   cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
 
@@ -147,8 +148,10 @@ Cypress.Commands.add('goToStore', () => {
 Cypress.Commands.add('fillInAddress', () => {
   cy.get('#billing_last_name').type('{selectAll}Johnson');
   cy.get('#billing_first_name').type('{selectAll}Test');
-  cy.get('#billing_postcode').type('{selectAll}48103');
+  cy.get('#billing_country').select('JP', {force: true});
+  cy.get('#billing_state').select('JP13', {force: true});
   cy.get('#billing_city').type('{selectAll}Musashino');
+  cy.get('#billing_postcode').type('{selectAll}180-0004');
   cy.get('#billing_address_1').type('{selectAll}a');
   cy.get('#billing_phone').type('{selectAll}123123213213213');
 


### PR DESCRIPTION
I updated test codes to pass the tests with the latest environment. The following changes were covered by this PR changes.

- Some labels are uppercased with CSS. Cypress requires `matchCase` option to be specified to ignore cases today.
- WooCommerce changed the billing form:
  - It uses combo boxes for country and state and it has the hidden select forms.
  - It validates a postal code.

### How to test

Please confirm the CI passed.
