### PR TITLE
Fix occasionally not handling refund webhooks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
        - "8000:80"
      restart: always
      environment:
+       WORDPRESS_DEV_ENV: 1
        WORDPRESS_DEBUG: 1
        WORDPRESS_DB_HOST: db:3306
        WORDPRESS_DB_NAME: wordpress

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -149,23 +149,24 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     public function validate_hmac($requestBody)
     {
-        $isDevEnv = getenv('WORDPRESS_DEV_ENV');
-        if ($isDevEnv) {
-            WC_Gateway_Komoju::log('Skipping IPN check in dev env');
-
-            return true;
-        }
-
         WC_Gateway_Komoju::log('Checking if IPN response is valid');
+
+        $isDevEnv = getenv('WORDPRESS_DEV_ENV');
 
         $hmacHeader = $_SERVER['HTTP_X_KOMOJU_SIGNATURE'];
 
         $calcHmac = hash_hmac('sha256', $requestBody, $this->webhookSecretToken);
 
         if ($hmacHeader != $calcHmac) {
-            WC_Gateway_Komoju::log('hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...');
+            if ($isDevEnv) {
+                WC_Gateway_Komoju::log('hmac codes (sent by Komoju / recalculated) don\'t match. Continuing the process because it\'s running in dev mode....');
 
-            return false;
+                return true;
+            } else {
+                WC_Gateway_Komoju::log('hmac codes (sent by Komoju / recalculated) don\'t match. Exiting the process...');
+
+                return false;
+            }
         }
 
         return true;

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -152,6 +152,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
         $isDevEnv = getenv('WORDPRESS_DEV_ENV');
         if ($isDevEnv) {
             WC_Gateway_Komoju::log('Skipping IPN check in dev env');
+
             return true;
         }
 
@@ -305,7 +306,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
         // Only handle full refunds, not partial
         WC_Gateway_Komoju::log('Only handling full refund. Controlling that order total equals amount refunded. Does ' . $amount_in_cents . ' equals ' . $webhookEvent->grand_total() . ' ?');
         if ($amount_in_cents == $webhookEvent->amount_refunded()) {
-            WC_Gateway_Komoju::log('Refunding order: '. $order->get_id());
+            WC_Gateway_Komoju::log('Refunding order: ' . $order->get_id());
             $order->update_status('refunded', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), strtolower($webhookEvent->status())));
         }
     }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -295,10 +295,11 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_refunded($order, $webhookEvent)
     {
+        $amount_in_cents = WC_Gateway_Komoju::to_cents($order->get_total(), $order->get_currency());
         // Only handle full refunds, not partial
-        WC_Gateway_Komoju::log('Only handling full refund. Controlling that order total equals amount refunded. Does ' . $order->get_total() . ' equals ' . $webhookEvent->grand_total() . ' ?');
-        if ($order->get_total() == ($webhookEvent->amount_refunded())) {
-            // Mark order as refunded
+        WC_Gateway_Komoju::log('Only handling full refund. Controlling that order total equals amount refunded. Does ' . $amount_in_cents . ' equals ' . $webhookEvent->grand_total() . ' ?');
+        if ($amount_in_cents == $webhookEvent->amount_refunded()) {
+            WC_Gateway_Komoju::log('Refunding order: '. $order->get_id());
             $order->update_status('refunded', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), strtolower($webhookEvent->status())));
         }
     }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -149,6 +149,12 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     public function validate_hmac($requestBody)
     {
+        $isDevEnv = getenv('WORDPRESS_DEV_ENV');
+        if ($isDevEnv) {
+            WC_Gateway_Komoju::log('Skipping IPN check in dev env');
+            return true;
+        }
+
         WC_Gateway_Komoju::log('Checking if IPN response is valid');
 
         $hmacHeader = $_SERVER['HTTP_X_KOMOJU_SIGNATURE'];

--- a/tests/cypress/e2e/refunded-webhook.cy.js
+++ b/tests/cypress/e2e/refunded-webhook.cy.js
@@ -1,0 +1,83 @@
+/// <reference types="cypress" />
+
+describe("KOMOJU for WooCommerce: Refunded webhook", () => {
+  beforeEach(() => {
+    cy.installWordpress();
+    cy.signinToWordpress();
+    cy.installWooCommerce();
+    cy.installKomoju();
+  });
+
+  it("sets an order as a refunded based on incoming refunded webhook", () => {
+    cy.createOrder().then(orderId => {
+      cy.request({
+        method: "POST",
+        url: "http://localhost:8000/?wc-api=WC_Gateway_Komoju",
+        headers: {
+          "X-Komoju-ID": "dummy",
+          "X-Komoju-Signature": "dummy",
+          "X-Komoju-Event": "payment.refunded",
+          "User-Agent": "Komoju-Webhook",
+          "Content-Type": "application/json",
+        },
+        body: {
+          id: "dummy",
+          type: "payment.refunded",
+          resource: "event",
+          data: {
+            id: "dummy",
+            resource: "payment",
+            status: "refunded",
+            amount: 1200,
+            tax: 0,
+            customer: null,
+            payment_deadline: "2023-02-19T14:59:59Z",
+            payment_details: {
+              type: "credit_card",
+              email: "dummy@dummy.com",
+              brand: "master",
+              last_four_digits: "3795",
+              month: 9,
+              year: 2024,
+            },
+            payment_method_fee: 0,
+            total: 1200,
+            currency: "EUR",
+            description: null,
+            captured_at: "2023-02-17T11:57:05Z",
+            external_order_num: `WC-${orderId}-A49R0D`, // <---- the order id
+            metadata: {
+              woocommerce_order_id: "255095",
+            },
+            created_at: "2023-02-17T11:57:01Z",
+            amount_refunded: 1200,
+            locale: "ja",
+            session: "dummy",
+            customer_family_name: null,
+            customer_given_name: null,
+            mcc: null,
+            statement_descriptor: null,
+            refunds: [
+              {
+                id: "dummy",
+                resource: "refund",
+                amount: 1200,
+                currency: "EUR",
+                payment: "dummy",
+                description: "Bulk Chargeback 2023-08-28",
+                created_at: "2023-08-28T02:13:46Z",
+                chargeback: true,
+              },
+            ],
+            refund_requests: [],
+          },
+          created_at: "2023-08-28T02:13:48Z",
+          reason: null,
+        },
+      });
+      cy.reload();
+      cy.get('#woocommerce-order-notes').should('include.text', 'Payment refunded via IPN.');
+      cy.get('#woocommerce-order-notes').should('include.text', 'Order status set to refunded.');
+    });
+  });
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -181,3 +181,16 @@ Cypress.Commands.add('iframe', { prevSubject: 'element' }, ($iframe) => {
   // https://on.cypress.io/wrap
   .then(cy.wrap)
 })
+
+Cypress.Commands.add('createOrder', () => {
+  cy.visit('/wp-admin/post-new.php?post_type=shop_order');
+  cy.get('.button.add-line-item').click();
+  cy.get('.button.add-order-item').click();
+  cy.get('.wc-backbone-modal-main .select2-selection.select2-selection--single').click();
+  cy.get('.select2-search--dropdown .select2-search__field').type('komoju');
+  cy.get('.select2-results__option--highlighted').click();
+  cy.get('#btn-ok').click();
+  cy.get('.calculate-action').click();
+  cy.get('.save_order').click();
+  return cy.get('#post_ID').invoke('val');
+});


### PR DESCRIPTION
## Summary
Fixing refund webhook issue for decimal currency orders (e.g., HKD). The plugin now properly converts amounts to cents for accurate comparisons.

## Screenshot
![demo](https://github.com/degica/komoju-woocommerce/assets/74097/c67c3701-aafd-4d6b-8567-02f0140080ff)
