### PR TITLE
Tweak WordPress and WooCommerce compatability versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -141,6 +141,14 @@ At the moment, this plugin has been tested and is known to work up to WordPress
 6.1.1 and WooCommerce 6.3.1. If you are using a later version, please contact
 us regarding this.
 
+= What should I do if I am using newer versions of WordPress and WooCommerce? =
+
+2024/01/31
+
+We recommend performing a fresh install of WordPress 6.1.1 and WooCommerce
+6.3.1 before proceeding to install this plugin. Downgrading from newer versions
+of WordPress and WooCommerce may result in issues with installing this plugin.
+
 = Where can I get more information? =
 
 Please contact contact@komoju.com if you have any questions about

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: degica
 Tags: WooCommerce,Payment Gateway,Komoju
 Requires at least: 5.3
-Tested up to: 6.0
+Tested up to: 6.1.1
 Stable tag: trunk
 Requires PHP: 7.2
 WC requires at least: 3.0.0
@@ -135,10 +135,11 @@ Go back to your Wordpress instance and set the "Webhook Secret Token" value on t
 
 == Frequently Asked Questions ==
 
-= What versions of WooCommerce is this compatible with? =
+= What versions of WordPress and WooCommerce is this compatible with? =
 
-At the moment, this plugin has been tested and is known to work up to version
-6.3.1. If you are using a later version, please contact us regarding this.
+At the moment, this plugin has been tested and is known to work up to WordPress
+6.1.1 and WooCommerce 6.3.1. If you are using a later version, please contact
+us regarding this.
 
 = Where can I get more information? =
 


### PR DESCRIPTION
Fixes: https://app.asana.com/0/1204577477850530/1206355454744621/f (see item 2 of pinned comment)

This PR updates the plugin documentation that appears on https://ja.wordpress.org/plugins/komoju-japanese-payments/: 

1. Update compatability versions that will appear on the details tab
2. Add an item to the FAQ section for merchants already on newer versions