### PR TITLE
Bump to 3.0.6

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 3.0.5
+Version: 3.0.6
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,9 @@ the installation of the module.
 
 == Changelog ==
 
+= 3.0.6 =
+Update docs for supported WordPress and WooCommerce versions.
+
 = 3.0.5 =
 Fix occasional instances of not correctly marking an order as refunded.
 Update available payment method list.


### PR DESCRIPTION
Follows: https://github.com/degica/komoju-woocommerce/pull/99

This PR bumps the plugin version to 3.0.6 following the documentation updates from the PR above.