### PR TITLE
Add JA FAQ translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,11 @@ You need to execute it every time after updating po files.
 #### Updating the existing po files
 
 Rather than having to copy and paste the existing translations across to the new pot file, you can use [poedit](https://poedit.net/download). After generating the POT file as above, open the `komoju-woocommerce-ja.po` file in Poedit, then go to Catalogue->Update from POT File, to automatically update the existing Japanese translations with the new schema.
+
+#### Updating plugin store page content
+
+WordPress provides a [readme template](https://wordpress.org/plugins/readme.txt)
+used to generate the plugin's page on the WordPress Store. We are using a third party
+Github action](https://github.com/10up/action-wordpress-plugin-deploy) to do this.
+See our [docs](https://github.com/degica/komoju-woocommerce/blob/master/docs/uploading_to_wordpress_store.md)
+for uploading newer versions of the plugin to the WordPress store.

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     3.0.4
+ * @version     3.0.7
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Settings_Page_Komoju
  * @extends     WC_Settings_Page
  *
- * @version     3.0.4
+ * @version     3.0.7
  *
  * @author      Komoju
  */

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 3.0.6
+Version: 3.0.7
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,18 @@ contact our support team (contact@komoju.com).
 Please contact contact@komoju.com if you have any questions about
 the installation of the module.
 
+= どのWordPress・WooCommerceのバージョンに対応していますか？=
+現時点でこのプラグインは、WordPress 6.1.1およびWooCommerce 6.3.1まで動作することが確認されています。
+それ以降のバージョンをお使いの場合は、以下をお試し頂くか、contact@komoju.comまでご連絡ください。
+
+= 新しいバージョンのWordPressとWooCommerceを使用している場合はどうすればよいですか？ =
+このプラグインをインストールする前に、まずWordPress 6.1.1とWooCommerce 6.3.1を新規インストールすることをお勧めします。
+新しいバージョンから旧バージョンへ一時的にダウングレードし、接続頂くことも可能ですが、新しいバージョンからダウングレードすると、このプラグインのインストールに問題が生じる可能性がございます。
+問題が発生した場合は、サポートチーム（contact@komoju.com）までご連絡ください。
+
+= 詳細はどこで入手できますか？=
+KOMOJUの接続方法についてご不明な点がありましたら、弊社のサポートチーム（contact@komoju.com） までお問合せください。
+
 == Changelog ==
 
 = 3.0.6 =

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,42 @@ We currently accept the following payment methods:
 - MyBank
 - Sofort
 
+== Frequently Asked Questions ==
+
+= What versions of WordPress and WooCommerce is this compatible with? =
+
+At the moment, this plugin has been tested and is known to work up to WordPress
+6.1.1 and WooCommerce 6.3.1. If you are using a later version, please check the
+next section or contact us regarding this.
+
+= What should I do if I am using newer versions of WordPress and WooCommerce? =
+
+2024/01/31
+
+We recommend performing a fresh install of WordPress 6.1.1 and WooCommerce
+6.3.1 before proceeding to install this plugin. You can temporarily downgrade
+from a newer version of WordPress and WooCommerce before continuing installation.
+However, downgrading from newer versions of WordPress and WooCommerce may result in
+issues with installing this plugin. If you are experiencing problems, please
+contact our support team (contact@komoju.com).
+
+= Where can I get more information? =
+
+Please contact contact@komoju.com if you have any questions about
+the installation of the module.
+
+= どのWordPress・WooCommerceのバージョンに対応していますか？=
+現時点でこのプラグインは、WordPress 6.1.1およびWooCommerce 6.3.1まで動作することが確認されています。
+それ以降のバージョンをお使いの場合は、以下をお試し頂くか、contact@komoju.comまでご連絡ください。
+
+= 新しいバージョンのWordPressとWooCommerceを使用している場合はどうすればよいですか？ =
+このプラグインをインストールする前に、まずWordPress 6.1.1とWooCommerce 6.3.1を新規インストールすることをお勧めします。
+新しいバージョンから旧バージョンへ一時的にダウングレードし、接続頂くことも可能ですが、新しいバージョンからダウングレードすると、このプラグインのインストールに問題が生じる可能性がございます。
+問題が発生した場合は、サポートチーム（contact@komoju.com）までご連絡ください。
+
+= 詳細はどこで入手できますか？=
+KOMOJUの接続方法についてご不明な点がありましたら、弊社のサポートチーム（contact@komoju.com） までお問合せください。
+
 == Installation ==
 
 1. Upload the plugin to your server where wordpress and WooCommerce are installed via FTP or other file transfer method to the wordpress/wp-content/plugins directory
@@ -132,42 +168,6 @@ To ensure that the WooCommerce plugin works correctly you will need to set up a 
 Ensure that the "Active" checkbox is also ticked and then click "Create Webhook".
 
 Go back to your Wordpress instance and set the "Webhook Secret Token" value on the Komoju Woocommerce plugin to be the same as the secret set for the webhook.
-
-== Frequently Asked Questions ==
-
-= What versions of WordPress and WooCommerce is this compatible with? =
-
-At the moment, this plugin has been tested and is known to work up to WordPress
-6.1.1 and WooCommerce 6.3.1. If you are using a later version, please check the
-next section or contact us regarding this.
-
-= What should I do if I am using newer versions of WordPress and WooCommerce? =
-
-2024/01/31
-
-We recommend performing a fresh install of WordPress 6.1.1 and WooCommerce
-6.3.1 before proceeding to install this plugin. You can temporarily downgrade
-from a newer version of WordPress and WooCommerce before continuing installation.
-However, downgrading from newer versions of WordPress and WooCommerce may result in
-issues with installing this plugin. If you are experiencing problems, please
-contact our support team (contact@komoju.com).
-
-= Where can I get more information? =
-
-Please contact contact@komoju.com if you have any questions about
-the installation of the module.
-
-= どのWordPress・WooCommerceのバージョンに対応していますか？=
-現時点でこのプラグインは、WordPress 6.1.1およびWooCommerce 6.3.1まで動作することが確認されています。
-それ以降のバージョンをお使いの場合は、以下をお試し頂くか、contact@komoju.comまでご連絡ください。
-
-= 新しいバージョンのWordPressとWooCommerceを使用している場合はどうすればよいですか？ =
-このプラグインをインストールする前に、まずWordPress 6.1.1とWooCommerce 6.3.1を新規インストールすることをお勧めします。
-新しいバージョンから旧バージョンへ一時的にダウングレードし、接続頂くことも可能ですが、新しいバージョンからダウングレードすると、このプラグインのインストールに問題が生じる可能性がございます。
-問題が発生した場合は、サポートチーム（contact@komoju.com）までご連絡ください。
-
-= 詳細はどこで入手できますか？=
-KOMOJUの接続方法についてご不明な点がありましたら、弊社のサポートチーム（contact@komoju.com） までお問合せください。
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,16 +138,19 @@ Go back to your Wordpress instance and set the "Webhook Secret Token" value on t
 = What versions of WordPress and WooCommerce is this compatible with? =
 
 At the moment, this plugin has been tested and is known to work up to WordPress
-6.1.1 and WooCommerce 6.3.1. If you are using a later version, please contact
-us regarding this.
+6.1.1 and WooCommerce 6.3.1. If you are using a later version, please check the
+next section or contact us regarding this.
 
 = What should I do if I am using newer versions of WordPress and WooCommerce? =
 
 2024/01/31
 
 We recommend performing a fresh install of WordPress 6.1.1 and WooCommerce
-6.3.1 before proceeding to install this plugin. Downgrading from newer versions
-of WordPress and WooCommerce may result in issues with installing this plugin.
+6.3.1 before proceeding to install this plugin. You can temporarily downgrade
+from a newer version of WordPress and WooCommerce before continuing installation.
+However, downgrading from newer versions of WordPress and WooCommerce may result in
+issues with installing this plugin. If you are experiencing problems, please
+contact our support team (contact@komoju.com).
 
 = Where can I get more information? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,9 @@ KOMOJUの接続方法についてご不明な点がありましたら、弊社�
 
 == Changelog ==
 
+= 3.0.7 =
+Add JA translations for plugin store page FAQ.
+
 = 3.0.6 =
 Update docs for supported WordPress and WooCommerce versions.
 


### PR DESCRIPTION
Fixes top comment from https://app.asana.com/0/1204577477850530/1206355454744621/1206482198931670.

This PR makes the following changes:
* Adds JA translations for the FAQ section
* Attempts to move promote visibility of FAQ section as requested by CS

CS team provided some JA translations for the FAQ section of our plugin's WordPress store page. I poked around our deploy Github action and noticed we are using a third party service to update plugin's store page contents. I'm not entirely clear on how the content is rendered, but I added some documentation to the README to help future developers out 🙌 