### PR TITLE
Try fixing IPN flakiness

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     3.0.7
+ * @version     3.0.8
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Settings_Page_Komoju
  * @extends     WC_Settings_Page
  *
- * @version     3.0.7
+ * @version     3.0.8
  *
  * @author      Komoju
  */

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -23,21 +23,21 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     public function __construct($gateway, $webhookSecretToken = '', $secret_key = '', $invoice_prefix = '', $useOnHold = false)
     {
-        add_action('invoke_komoju_ipn_handler', [$this, 'check_response']);
+        add_filter('invoke_komoju_ipn_handler', [$this, 'check_response'], 10, 1);
         add_action('valid_komoju_standard_ipn_request', [$this, 'valid_response']);
         add_action('komoju_capture_payment_async', [$this, 'payment_complete_async'], 10, 3);
 
-        $this->gateway                = $gateway;
-        $this->webhookSecretToken	  	 = $webhookSecretToken;
-        $this->secret_key	   	        = $secret_key;
-        $this->invoice_prefix			      = $invoice_prefix;
-        $this->useOnHold              = $useOnHold;
+        $this->gateway            = $gateway;
+        $this->webhookSecretToken = $webhookSecretToken;
+        $this->secret_key         = $secret_key;
+        $this->invoice_prefix     = $invoice_prefix;
+        $this->useOnHold          = $useOnHold;
     }
 
     /**
      * Check for Komoju IPN or Session Response
      */
-    public function check_response()
+    public function check_response($_handled)
     {
         // callback from session page
         if (isset($_GET['session_id'])) {
@@ -62,13 +62,13 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                 $payment_url = $order->get_checkout_payment_url(false);
                 wp_redirect($payment_url);
             }
-            exit;
+            return true;
         }
 
         // Quick setup POST from KOMOJU
         if (isset($_POST['secret_key'])) {
             $this->quick_setup($_POST);
-            exit;
+            return true;
         }
 
         // Webhook (IPN)
@@ -78,8 +78,9 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
             // NOTE: direct function call doesn't work
             do_action('valid_komoju_standard_ipn_request', $webhookEvent);
-            exit;
+            return true;
         }
+
         wp_die('Failed to verify KOMOJU authenticity', 'Komoju IPN', ['response' => 401]);
     }
 

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -62,12 +62,14 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                 $payment_url = $order->get_checkout_payment_url(false);
                 wp_redirect($payment_url);
             }
+
             return true;
         }
 
         // Quick setup POST from KOMOJU
         if (isset($_POST['secret_key'])) {
             $this->quick_setup($_POST);
+
             return true;
         }
 
@@ -78,6 +80,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
             // NOTE: direct function call doesn't work
             do_action('valid_komoju_standard_ipn_request', $webhookEvent);
+
             return true;
         }
 

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -23,8 +23,8 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     public function __construct($gateway, $webhookSecretToken = '', $secret_key = '', $invoice_prefix = '', $useOnHold = false)
     {
-        add_action('woocommerce_api_wc_gateway_komoju', [$this, 'check_response']);
-        add_action('valid-komoju-standard-ipn-request', [$this, 'valid_response']);
+        add_action('invoke_komoju_ipn_handler', [$this, 'check_response']);
+        add_action('valid_komoju_standard_ipn_request', [$this, 'valid_response']);
         add_action('komoju_capture_payment_async', [$this, 'payment_complete_async'], 10, 3);
 
         $this->gateway                = $gateway;
@@ -77,7 +77,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             $webhookEvent = new WC_Gateway_Komoju_Webhook_Event($entityBody);
 
             // NOTE: direct function call doesn't work
-            do_action('valid-komoju-standard-ipn-request', $webhookEvent);
+            do_action('valid_komoju_standard_ipn_request', $webhookEvent);
             exit;
         }
         wp_die('Failed to verify KOMOJU authenticity', 'Komoju IPN', ['response' => 401]);

--- a/index.php
+++ b/index.php
@@ -78,8 +78,18 @@ function woocommerce_komoju_init()
         // Force WC to load our gateway, causing WC_Gateway_Komoju_IPN_Handler to get instantiated.
         WC()->payment_gateways()->payment_gateways();
 
-        // This action is registered when WC_Gateway_Komoju_IPN_Handler is instantiated.
-        do_action('invoke_komoju_ipn_handler');
+        // When WC_Gateway_Komoju_IPN_Handler is instantiated, this filter should be registered.
+        $handled = apply_filters('invoke_komoju_ipn_handler', false);
+
+        // Catch unexpected case where the filter is NOT registered
+        if (!$handled) {
+            header('X-Komoju-Error: komoju gateway not loaded');
+            wp_die(
+                'gateway (and thus IPN handler) not loaded',
+                'KOMOJU WooCommerce plugin',
+                ['status' => 500]
+            );
+        }
     }
 
     add_filter('woocommerce_payment_gateways', 'woocommerce_add_komoju_gateway');

--- a/index.php
+++ b/index.php
@@ -73,8 +73,18 @@ function woocommerce_komoju_init()
         return '<script type="module" src="' . esc_attr($src) . '"></script>';
     }
 
+    function woocommerce_komoju_handle_http_request()
+    {
+        // Force WC to load our gateway, causing WC_Gateway_Komoju_IPN_Handler to get instantiated.
+        WC()->payment_gateways()->payment_gateways();
+
+        // This action is registered when WC_Gateway_Komoju_IPN_Handler is instantiated.
+        do_action('invoke_komoju_ipn_handler');
+    }
+
     add_filter('woocommerce_payment_gateways', 'woocommerce_add_komoju_gateway');
     add_filter('woocommerce_get_settings_pages', 'woocommerce_add_komoju_settings_page');
+    add_action('woocommerce_api_wc_gateway_komoju', 'woocommerce_komoju_handle_http_request');
 
     add_action('wp_enqueue_scripts', 'woocommerce_komoju_load_scripts');
     add_filter('script_loader_tag', 'woocommerce_komoju_load_script_as_module', 10, 3);

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 3.0.7
+Version: 3.0.8
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,10 @@ Go back to your Wordpress instance and set the "Webhook Secret Token" value on t
 
 == Changelog ==
 
+= 3.0.8 =
+Register IPN handler outside of gateway initializer.
+Hopefully fixes an issue where automatic updates cause webhooks to stop working.
+
 = 3.0.7 =
 Add JA translations for plugin store page FAQ.
 


### PR DESCRIPTION
We got a bug report about webhooks getting dropped after automatic updates. I noticed that we're not following [the official advice on hooks within gateway initializers](https://developer.woo.com/docs/woocommerce-payment-gateway-api/#4-hooks-in-gateways), which might be the cause. This PR moves the API action registration outside of the gateway initialization code. Hopefully this fixes the issue.

I had a hard time reproducing the original issue, but I was able to confirm that this change doesn't break regular webhook processing.