### PR TITLE
Fix E2E admin spec

### DIFF
--- a/tests/cypress/e2e/admin.cy.js
+++ b/tests/cypress/e2e/admin.cy.js
@@ -32,7 +32,7 @@ describe('KOMOJU for WooCommerce: Admin', () => {
     cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
 
     cy.get('.komoju-endpoint-komoju_woocommerce_api_endpoint').contains('Edit').click();
-    cy.get('#komoju_woocommerce_api_endpoint').type('{selectAll}https://requestbin.labs.degica.com');
+    cy.get('#komoju_woocommerce_api_endpoint').type('{selectAll}https://example.com');
     cy.contains('Save changes').click();
 
     cy.contains('Payment methods').click();


### PR DESCRIPTION
This PR fixes failing E2E: https://github.com/degica/komoju-woocommerce/commit/ac3e69bf64089a07c1b3d92f2481e99e70184909/checks/21135979902/logs

https://requestbin.labs.degica.com is currently down for the count, and after [some discussion](https://degica.slack.com/archives/C03S3UEEE/p1706849843260729) it seems ok to stop using it. In the failing spec the page wasn't loading so cypress hinted the spec exceeding the default `pageLoadTimeout`, so this PR uses a more reliable 🤔 page to attempt and fail a KOMOJU account connection. I think it's safe to send the connection request to example.com?