### PR TITLE
Fix cancellation webhook bug

### DIFF
--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -236,7 +236,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_cancelled($order, $webhookEvent)
     {
-        if (!$this->is_order_cancellable($order)) {
+        if (!$this->is_order_cancellable($order, $webhookEvent)) {
             $transaction_id     = $order->get_transaction_id();
             $external_order_num = $webhookEvent->external_order_num();
             WC_Gateway_Komoju::log('Aborting, transaction_id: ' . $transaction_id . ' and external_order_num: ' . $external_order_num . ' do not match.');
@@ -251,7 +251,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      *
      * @return bool return true if the order is cancellable
      */
-    protected function is_order_cancellable($order)
+    protected function is_order_cancellable($order, $webhookEvent)
     {
         $transaction_id = $order->get_transaction_id();
         if (empty($transaction_id)) {


### PR DESCRIPTION
# Context
A merchant discovered the error log during WC maintenance.

```
CRITICAL Uncaught Error: Call to a member function uuid() on null in /home/kusanagi/de300fb99ec8ad9cd9b44e25/DocumentRoot/wp-content/plugins/komoju-japanese-payments/includes/class-wc-gateway-komoju-ipn-handler.php:256
```

The specific line of code causing issues was `$transaction_id == $webhookEvent->uuid()` since `$webhookEvent` wasn't passed to the `is_order_cancellable` function. This PR updates the `is_order_cancellable` method to properly receive `$webhookEvent` so we don't call `uuid` on a nil variable.

Fixes: https://app.asana.com/0/1203431131393579/1206550902062204/f

# Testing
Probably ok to just check the code on this one. If you want to test it, you can:
1. Setup a local env to test the Komoju WooCommerce plugin (see https://www.notion.so/WooCommerce-Testing-Demo-9bbada14ee314a379e141f8d512dde4f).
2. Buy an item on your WooCommerce shop. Paying with konbini is probably easiest.
3. Cancel the payment in the Komoju admin panel (triggers `is_order_cancellable` in the same way as an expiring payment does).
4. Ensure there's no issues with the webhook response by checking the Payment webhook responses in the Komoju admin panel.