### PR TITLE
Update KOMOJU WooCommerce Integration for WooCommerce 8.8.2 Compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM wordpress:6.1.1
+FROM wordpress:6.5.2
 
 ARG woocommerce_version
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip wget gettext vim bash-completion ssh git xvfb chromium sudo \
     && wget https://downloads.wordpress.org/plugin/woocommerce.${woocommerce_version}.zip -O /tmp/woocommerce.zip \
-    && wget https://downloads.wordpress.org/plugin/relative-url.0.1.7.zip -O /tmp/relative-url.zip \
+    && wget https://downloads.wordpress.org/plugin/relative-url.0.1.8.zip -O /tmp/relative-url.zip \
     && cd /usr/src/wordpress/wp-content/plugins \
     && unzip /tmp/woocommerce.zip \
     && unzip /tmp/relative-url.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:6.5.2
+FROM wordpress:6.5.3
 
 ARG woocommerce_version
 

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -28,6 +28,28 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     /** @var WC_Logger Logger instance */
     public static $log;
 
+    /* Fix for Deprecated: Creation of dynamic property */
+    /** @var bool Debugging enabled */
+    public $debug;
+
+    /** @var string Invoice prefix */
+    public $invoice_prefix;
+    
+    /** @var string Secret key */
+    public $secretKey;
+
+    /** @var string Webhook secret token */
+    public $webhookSecretToken;
+
+    /** @var KomojuApi */
+    public $komoju_api;
+
+    /** @var string Instructions */
+    public $instructions;
+
+    /** @var bool Use on hold */
+    public $useOnHold;
+
     /**
      * Constructor for the gateway.
      */

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -71,7 +71,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
 
         // Define user set variables
         $this->title                = $this->get_option('title');
-        $this->description          = $this->get_option('description');
+        $this->description          = $this->get_option('description') ?: $this->default_description();
         $this->instructions         = $this->get_option('instructions', $this->description);
         $this->useOnHold            = $this->get_option('useOnHold');
 
@@ -311,6 +311,14 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     protected function default_title()
     {
         return __('Komoju', 'komoju-woocommerce');
+    }
+
+    protected function default_description()
+    {
+        return sprintf(
+            __('%s payments powered by KOMOJU', 'komoju-woocommerce'),
+            $this->default_title()
+        );
     }
 
     public static function to_cents($total, $currency = '')

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Gateway_Komoju
  * @extends     WC_Payment_Gateway
  *
- * @version     3.0.9
+ * @version     3.1.0
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
  * @class       WC_Settings_Page_Komoju
  * @extends     WC_Settings_Page
  *
- * @version     3.0.9
+ * @version     3.1.0
  *
  * @author      Komoju
  */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
        context: .
        dockerfile: Dockerfile
        args:
-         woocommerce_version: 8.8.2
+         woocommerce_version: 8.8.3
      ports:
        - "8000:80"
      restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
      restart: always
      environment:
        WORDPRESS_DEV_ENV: 1
-       WORDPRESS_DEBUG: 0
+       WORDPRESS_DEBUG: 1
        WORDPRESS_DB_HOST: db:3306
        WORDPRESS_DB_NAME: wordpress
        WORDPRESS_DB_USER: wordpress

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,13 +21,13 @@ services:
        context: .
        dockerfile: Dockerfile
        args:
-         woocommerce_version: 6.3.1
+         woocommerce_version: 8.8.2
      ports:
        - "8000:80"
      restart: always
      environment:
        WORDPRESS_DEV_ENV: 1
-       WORDPRESS_DEBUG: 1
+       WORDPRESS_DEBUG: 0
        WORDPRESS_DB_HOST: db:3306
        WORDPRESS_DB_NAME: wordpress
        WORDPRESS_DB_USER: wordpress

--- a/frontend.js
+++ b/frontend.js
@@ -1,0 +1,28 @@
+function registerPaymentMethod(paymentMethod) {
+    let name = `${paymentMethod.id}`
+    let testSetting = window.wc.wcSettings.getSetting(`${name}_data`, {});
+
+    const settings = window.wc.wcSettings.getSetting(`${name}_data`, {});
+    const label = window.wp.htmlEntities.decodeEntities(settings.title) || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway');
+    const Content = () => {
+        return window.wp.htmlEntities.decodeEntities(settings.description || '');
+    };
+
+    const Block_Gateway = {
+        name: name,
+        label: label,
+        content: Object(window.wp.element.createElement)(Content, null),
+        edit: Object(window.wp.element.createElement)(Content, null),
+        canMakePayment: () => true,
+        ariaLabel: label,
+        supports: {
+            features: settings.supports || ['products'],
+        },
+    };
+    window.wc.wcBlocksRegistry.registerPaymentMethod(Block_Gateway);
+}
+
+paymentMethodData = window.wc.wcSettings.getSetting('paymentMethodData', {});
+Object.values(paymentMethodData).forEach((value) => {
+    registerPaymentMethod(value);
+});

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -12,11 +12,11 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 	{
 		$this->gateway = $gateway;
 		$this->name = $gateway->id;
-		$this->settings = $gateway->payment_method->settings;
 	}
 
 	public function initialize()
 	{
+		$this->settings = $this->gateway->payment_method['settings'] ?? [];
 		$this->settings = get_option('woocommerce_test_komoju_settings', []);
 	}
 

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -1,0 +1,53 @@
+<?php
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
+{
+	private $gateway;
+	protected $name;
+
+	public function __construct(WC_Gateway_Komoju_Single_Slug $gateway)
+	{
+		$this->gateway = $gateway;
+		$this->name = $gateway->id;
+	}
+
+	public function initialize()
+	{
+		$this->settings = get_option('woocommerce_test_komoju_settings', []);
+	}
+
+	public function is_active()
+	{
+		return $this->gateway->is_available();
+	}
+
+	public function get_payment_method_script_handles()
+	{
+		wp_register_script(
+			'komoju-payment-blocks-integration',
+			plugin_dir_url(__FILE__) . '../frontend.js',
+			[
+				'wc-blocks-registry',
+				'wc-settings',
+				'wp-element',
+				'wp-html-entities',
+			],
+			null,
+			true
+		);
+
+		return ['komoju-payment-blocks-integration'];
+	}
+
+	public function get_payment_method_data()
+	{
+		return [
+			'title' => $this->gateway->title,
+			'description' => $this->gateway->method_description,
+			'id' => $this->name,
+		];
+	}
+}
+?>

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -8,7 +8,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 	protected $name;
 	protected $settings;
 
-	public function __construct(WC_Gateway_Komoju $gateway)
+	public function __construct(WC_Gateway_Komoju_Single_Slug $gateway)
 	{
 		$this->gateway = $gateway;
 		$this->name = $gateway->id;

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -8,7 +8,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 	protected $name;
 	protected $settings;
 
-	public function __construct(WC_Gateway_Komoju_Single_Slug $gateway)
+	public function __construct(WC_Gateway_Komoju $gateway)
 	{
 		$this->gateway = $gateway;
 		$this->name = $gateway->id;
@@ -48,7 +48,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 		return [
 			'id' => $this->name,
 			'title' => $this->gateway->title,
-			'description' => $this->gateway->method_description,
+			'description' => $this->gateway->description,
 			'supports' => array_filter($this->gateway->supports, array($this->gateway, 'supports')),
 			// 'paymentFields' => $this->gateway->payment_fields()
 		];

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -6,11 +6,13 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 {
 	private $gateway;
 	protected $name;
+	protected $settings;
 
 	public function __construct(WC_Gateway_Komoju_Single_Slug $gateway)
 	{
 		$this->gateway = $gateway;
 		$this->name = $gateway->id;
+		$this->settings = $gateway->payment_method->settings;
 	}
 
 	public function initialize()
@@ -27,7 +29,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 	{
 		wp_register_script(
 			'komoju-payment-blocks-integration',
-			plugin_dir_url(__FILE__) . '../frontend.js',
+			plugin_dir_url(__FILE__) . './js/komoju-checkout-blocks.js',
 			[
 				'wc-blocks-registry',
 				'wc-settings',
@@ -44,9 +46,11 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 	public function get_payment_method_data()
 	{
 		return [
+			'id' => $this->name,
 			'title' => $this->gateway->title,
 			'description' => $this->gateway->method_description,
-			'id' => $this->name,
+			'supports' => array_filter($this->gateway->supports, array($this->gateway, 'supports')),
+			// 'paymentFields' => $this->gateway->payment_fields()
 		];
 	}
 }

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -67,6 +67,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 			'publishableKey' => $this->gateway->publishableKey,
 			'session' => json_encode($checkout_session),
 			'paymentType' => $this->gateway->payment_method['type_slug'],
+			'locale' => $this->gateway->locale
 		];
 	}
 }

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -45,12 +45,28 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 
 	public function get_payment_method_data()
 	{
+		if (!is_checkout()) {
+			return;
+		}
+
+		// We lazily fetch one session to be shared by all payment methods with dynamic fields.
+		static $checkout_session;
+		if (is_null($checkout_session)) {
+			$checkout_session = $this->gateway->create_session_for_fields();
+		}
+
 		return [
 			'id' => $this->name,
 			'title' => $this->gateway->title,
 			'description' => $this->gateway->description,
 			'supports' => array_filter($this->gateway->supports, array($this->gateway, 'supports')),
-			// 'paymentFields' => $this->gateway->payment_fields()
+			// 'paymentFields' => $this->gateway->payment_fields(),
+			'icon' => $this->gateway->icon,
+			'tokenName' => "komoju_payment_token",
+			'komojuApi' => KomojuApi::endpoint(),
+			'publishableKey' => $this->gateway->publishableKey,
+			'session' => json_encode($checkout_session),
+			'paymentType' => $this->gateway->payment_method['type_slug'],
 		];
 	}
 }

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -12,6 +12,13 @@ include_once 'class-wc-gateway-komoju-webhook-event.php';
  */
 class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 {
+    /* Fix for Deprecated: Creation of dynamic property */
+    /** @var string $publishableKey */
+    public $publishableKey;
+
+    /** @var array $payment_method */
+    public $payment_method;
+
     public function __construct($payment_method)
     {
         $slug = $payment_method['type_slug'];

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -188,6 +188,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
     public function process_payment($order_id, $payment_type = null)
     {
+        $order = wc_get_order($order_id);
         // If we have a token from <komoju-fields>, we can process payment immediately.
         // Otherwise we will redirect to the KOMOJU hosted page.
         $token = sanitize_text_field($_POST['komoju_payment_token']);
@@ -197,7 +198,10 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
         }
 
         $session = $this->create_session_for_order($order_id, $payment_type);
-        $result  = $this->komoju_api->paySession($session->id, ['payment_details' => $token]);
+        $result  = $this->komoju_api->paySession($session->id, [
+            'customer_email' =>  $order->get_billing_email(),
+            'payment_details' => $token
+        ]);
 
         if ($result->redirect_url) {
             return [

--- a/includes/gateway-settings-komoju.php
+++ b/includes/gateway-settings-komoju.php
@@ -28,6 +28,13 @@ return [
         'default'     => $this->default_title(),
         'desc_tip'    => true,
     ],
+    'description' => [
+        'title'       => __('Description', 'komoju-woocommerce'),
+        'type'        => 'textarea',
+        'description' => __('This controls the description which the user sees during checkout.', 'komoju-woocommerce'),
+        'default'     => $this->default_description(),
+        'desc_tip'    => true,
+    ],
     'useOnHold' => [
         'title'       => __('Use on-hold status for pending payments', 'komoju-woocommerce'),
         'type'        => 'checkbox',

--- a/includes/js/komoju-checkout-blocks.js
+++ b/includes/js/komoju-checkout-blocks.js
@@ -16,7 +16,7 @@ function registerPaymentMethod(paymentMethod) {
     });
 
     const label = createElement('div', {
-        style: { display: 'block', alignItems: 'center', justifyContent: 'center' }
+        style: { display: 'block', alignItems: 'center', justifyContent: 'center', width: '100%' }
     },
         window.wp.htmlEntities.decodeEntities(settings.title || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway')),
         createElement('img', {

--- a/includes/js/komoju-checkout-blocks.js
+++ b/includes/js/komoju-checkout-blocks.js
@@ -11,6 +11,7 @@ function registerPaymentMethod(paymentMethod) {
         'publishable-key': settings.publishableKey,
         'session': settings.session,
         'payment-type': settings.paymentType,
+        'locale': settings.locale,
         style: { display: 'none' },
     });
 

--- a/includes/js/komoju-checkout-blocks.js
+++ b/includes/js/komoju-checkout-blocks.js
@@ -29,6 +29,7 @@ function registerPaymentMethod(paymentMethod) {
 
     const KomojuComponent = ({ activePaymentMethod, emitResponse, eventRegistration }) => {
         const { onPaymentSetup } = eventRegistration;
+        const komojuFieldEnabledMethods = ['komoju_credit_card', 'komoju_konbini', 'komoju_bank_transfer']
 
         useEffect(() => {
             const komojuField = document.querySelector(`komoju-fields[payment-type='${paymentMethod.paymentType}']`);
@@ -37,12 +38,7 @@ function registerPaymentMethod(paymentMethod) {
             const unsubscribe = onPaymentSetup(async () => {
                 console.log('onPaymentSetup', paymentMethod.id, activePaymentMethod)
                 if (paymentMethod.id != activePaymentMethod) return;
-                // Exceptions
-                if (paymentMethod.id === 'komoju_paidy') return;
-                if (paymentMethod.id === 'komoju_net_cash') return;
-                if (paymentMethod.id === 'komoju_bit_cash') return;
-                if (paymentMethod.id === 'komoju_web_money') return;
-                if (paymentMethod.id === 'komoju_pay_easy') return;
+                if (!komojuFieldEnabledMethods.includes(paymentMethod.id)) return;
 
                 if (komojuField && typeof komojuField.submit === 'function') {
                     var submitResult = await komojuField.broker.send({ type: 'submit' });

--- a/includes/js/komoju-checkout-blocks.js
+++ b/includes/js/komoju-checkout-blocks.js
@@ -1,8 +1,30 @@
+const { useEffect, useCallback, useRef, createElement } = window.wp.element;
+
 function registerPaymentMethod(paymentMethod) {
     let name = `${paymentMethod.id}`
 
     const settings = window.wc.wcSettings.getSetting(`${name}_data`, {});
-    const label = window.wp.htmlEntities.decodeEntities(settings.title) || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway');
+
+    const komojuField = createElement('komoju-fields', {
+        'name': 'komoju_payment_token',
+        'komoju-api': settings.komojuApi,
+        'publishable-key': settings.publishableKey,
+        'session': settings.session,
+        'payment-type': settings.paymentType,
+        style: { display: 'none' },
+    });
+
+    const label = createElement('div', {
+        style: { display: 'block', alignItems: 'center', justifyContent: 'center' }
+    },
+        window.wp.htmlEntities.decodeEntities(settings.title || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway')),
+        createElement('img', {
+            src: settings.icon,
+            alt: settings.title || 'Payment Method Icon',
+            style: { display: 'flex', alignItems: 'center', justifyContent: 'center', marginLeft: '10px' }
+        }),
+        komojuField,
+    );
     const Content = () => {
         return window.wp.htmlEntities.decodeEntities(settings.description || '');
     };
@@ -10,10 +32,10 @@ function registerPaymentMethod(paymentMethod) {
     const Block_Gateway = {
         name: name,
         label: label,
-        content: Object(window.wp.element.createElement)(Content, null),
-        edit: Object(window.wp.element.createElement)(Content, null),
+        content: createElement(Content, null),
+        edit: createElement(Content, null),
         canMakePayment: () => true,
-        ariaLabel: label,
+        ariaLabel: settings.title || 'Payment Method',
         supports: {
             features: settings.supports || ['products'],
         },

--- a/includes/js/komoju-checkout-blocks.js
+++ b/includes/js/komoju-checkout-blocks.js
@@ -1,6 +1,5 @@
 function registerPaymentMethod(paymentMethod) {
     let name = `${paymentMethod.id}`
-    let testSetting = window.wc.wcSettings.getSetting(`${name}_data`, {});
 
     const settings = window.wc.wcSettings.getSetting(`${name}_data`, {});
     const label = window.wp.htmlEntities.decodeEntities(settings.title) || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway');

--- a/index.php
+++ b/index.php
@@ -122,7 +122,7 @@ function woocommerce_komoju_init()
 
         if ($gateways) {
             foreach ($gateways as $gateway) {
-                if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju) {
+                if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
                     add_action(
                         'woocommerce_blocks_payment_method_type_registration',
                         function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) use ($gateway) {

--- a/index.php
+++ b/index.php
@@ -122,7 +122,7 @@ function woocommerce_komoju_init()
 
         if ($gateways) {
             foreach ($gateways as $gateway) {
-                if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
+                if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju) {
                     add_action(
                         'woocommerce_blocks_payment_method_type_registration',
                         function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) use ($gateway) {

--- a/index.php
+++ b/index.php
@@ -64,6 +64,7 @@ function woocommerce_komoju_init()
 
         wp_enqueue_script('komoju-fields', $komoju_fields_js);
     }
+
     function woocommerce_komoju_load_script_as_module($tag, $handle, $src)
     {
         if ($handle !== 'komoju-fields') {
@@ -107,7 +108,6 @@ function woocommerce_komoju_init()
             return;
 
         require_once 'includes/class-wc-gateway-komoju-block.php';
-        require_once 'includes/test-komoju-gateway.php';
     }
 
     add_action('woocommerce_blocks_loaded', 'register_komoju_payment_method_type');

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -94,7 +94,13 @@ class KomojuApi
     // );
     private function post($uri, $payload)
     {
-        $payload['fraud_details'] = array('customer_ip' => $_SERVER['REMOTE_ADDR']);
+        $payload['fraud_details'] = array(
+            'customer_ip' => $_SERVER['REMOTE_ADDR'],
+            'customer_email' => $payload['customer_email'],
+            'browser_language' => $_SERVER['HTTP_ACCEPT_LANGUAGE'],
+            'browser_user_agent' => $_SERVER['HTTP_USER_AGENT'],
+        );
+
         $ch        = curl_init($this->endpoint . $uri);
         $data_json = json_encode($payload);
         curl_setopt($ch, CURLOPT_POST, true);

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -94,6 +94,7 @@ class KomojuApi
     // );
     private function post($uri, $payload)
     {
+        $payload['fraud_details'] = array('customer_ip' => $_SERVER['REMOTE_ADDR']);
         $ch        = curl_init($this->endpoint . $uri);
         $data_json = json_encode($payload);
         curl_setopt($ch, CURLOPT_POST, true);

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -96,7 +96,7 @@ class KomojuApi
     {
         $payload['fraud_details'] = array(
             'customer_ip' => $_SERVER['REMOTE_ADDR'],
-            'customer_email' => $payload['customer_email'],
+            'customer_email' => $payload['customer_email'] ?? '',
             'browser_language' => $_SERVER['HTTP_ACCEPT_LANGUAGE'],
             'browser_user_agent' => $_SERVER['HTTP_USER_AGENT'],
         );

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -2,6 +2,11 @@
 
 class KomojuApi
 {
+    /* Fix for Deprecated: Creation of dynamic property */
+    public $endpoint;
+    public $via;
+    public $secretKey;
+
     public static function defaultEndpoint()
     {
         return 'https://komoju.com';


### PR DESCRIPTION
# Description

This pull request updates the KOMOJU WooCommerce integration to be compatible with WooCommerce version 8.8.2. Key updates include modifications to Docker configurations, plugin file adjustments, and enhancements to the checkout block to ensure smooth integration with the latest WooCommerce changes.

## Changes

### Checkout block support

  - Updated to use WooCommerce version 8.8.2 
  - Incremented version numbers in class-wc-gateway-komoju.php and class-wc-settings-page-komoju.php
  - New Implementation Files: 
    - Added class-wc-gateway-komoju-block.php and associated JavaScript file komoju-checkout-blocks.js to support WooCommerce Blocks. This change allows the KOMOJU payment methods to integrate seamlessly with the new WooCommerce Blocks checkout process.
  - index.php: Updated plugin metadata and added registration hooks for the new payment method types introduced in WooCommerce Blocks.
  - Add Description: This is mainly because `Komoju` module itself. I cannot use `method_description` for Komoju, because the default message is set as
  > "Includes all Komoju payment methods. Not recommended, since the name 'KOMOJU' is not recognized by most customers and refunds through WooCommerce are not supported."
  
So, I'd rather show the `Komoju powered by Komoju` like other payment methods.
  
![image](https://github.com/degica/komoju-woocommerce/assets/16696001/3a554c67-ed6b-4f75-8c66-827de7188024)

![image](https://github.com/degica/komoju-woocommerce/assets/16696001/dc6f26cd-6ecc-4520-ab43-9b58dfa0dc18)

And, I'd added `description` field which user can modify description message for the above reason.

![image](https://github.com/degica/komoju-woocommerce/assets/16696001/f98a93b9-80df-43e3-95c9-4c65b70c0605)

  
### Fix Deprecated Dynamic Property Creation in PHP 8.2

- The PHP 8.2 update introduced a deprecation notice for dynamic properties, which impacts the WC_Gateway_Komoju class and the others classes. This was causing a deprecated notice when attempting to dynamically create the $debug and other properties.
- Added explicit declaration of the variables
