### PR TITLE
Fix plugin conflicts in 3.1.0

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  *
  * @extends     WC_Payment_Gateway
  *
- * @version     3.1.0
+ * @version     3.1.2
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  *
  * @extends     WC_Settings_Page
  *
- * @version     3.1.0
+ * @version     3.1.2
  *
  * @author      Komoju
  */

--- a/includes/js/komoju-checkout-blocks.js
+++ b/includes/js/komoju-checkout-blocks.js
@@ -1,105 +1,113 @@
-const { useEffect, useCallback, useRef, createElement } = window.wp.element;
+const KomojuPaymentModule = (() => {
+    const { useEffect, useCallback, useRef, createElement } = window.wp.element;
 
-function registerPaymentMethod(paymentMethod) {
-    let name = `${paymentMethod.id}`
-    const settings = window.wc.wcSettings.getSetting(`${name}_data`, {});
+    function registerPaymentMethod(paymentMethod) {
+        let name = `${paymentMethod.id}`
+        const settings = window.wc.wcSettings.getSetting(`${name}_data`, {});
 
-    const komojuFields = createElement('komoju-fields', {
-        'token': '',
-        'name': 'komoju_payment_token',
-        'komoju-api': settings.komojuApi,
-        'publishable-key': settings.publishableKey,
-        'session': settings.session,
-        'payment-type': settings.paymentType,
-        'locale': settings.locale,
-        style: { display: 'none' },
-    });
+        const komojuFields = createElement('komoju-fields', {
+            'token': '',
+            'name': 'komoju_payment_token',
+            'komoju-api': settings.komojuApi,
+            'publishable-key': settings.publishableKey,
+            'session': settings.session,
+            'payment-type': settings.paymentType,
+            'locale': settings.locale,
+            style: { display: 'none' },
+        });
 
-    const label = createElement('div', {
-        style: { display: 'block', alignItems: 'center', justifyContent: 'center', width: '100%' }
-    },
-        window.wp.htmlEntities.decodeEntities(settings.title || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway')),
-        settings.icon ?
-        createElement('img', {
-            src: settings.icon,
-            alt: settings.title || 'Payment Method Icon',
-            style: { display: 'flex', alignItems: 'center', justifyContent: 'center', marginLeft: '10px' }
-        }) : null,
-        komojuFields
-    );
-
-    const KomojuComponent = ({ activePaymentMethod, emitResponse, eventRegistration }) => {
-        const { onPaymentSetup } = eventRegistration;
-        const komojuFieldEnabledMethods = ['komoju_credit_card', 'komoju_konbini', 'komoju_bank_transfer']
-
-        useEffect(() => {
-            const komojuField = document.querySelector(`komoju-fields[payment-type='${paymentMethod.paymentType}']`);
-            komojuField.style.display = 'block';
-
-            const unsubscribe = onPaymentSetup(async () => {
-                if (paymentMethod.id != activePaymentMethod) return;
-                if (!komojuFieldEnabledMethods.includes(paymentMethod.id)) return;
-
-                if (!(komojuField || typeof komojuField.submit === 'function')) {
-                    return {
-                        type: emitResponse.responseTypes.ERROR,
-                        message: 'There was an error',
-                    };
-                }
-
-                function submitFields(fields) {
-                    return new Promise(async (resolve, reject) => {
-                        fields.addEventListener("komoju-invalid", reject);
-                        const token = await fields.submit();
-                        fields.removeEventListener("komoju-invalid", reject);
-                        if (token) resolve(token);
-                    });
-                }
-
-                try {
-                    const token = await submitFields(komojuField);
-                    return {
-                        type: emitResponse.responseTypes.SUCCESS,
-                        meta: {
-                            paymentMethodData: {
-                                komoju_payment_token: token.id
-                            },
-                        },
-                    };
-                } catch (e) {
-                    return {
-                        type: emitResponse.responseTypes.ERROR,
-                        message: e.detail.errors[0].message,
-                    };
-                }
-            });
-
-            return () => {
-                komojuField.style.display = 'none';
-                unsubscribe();
-            };
-        }, [
-            activePaymentMethod,
-            emitResponse.responseTypes.ERROR,
-            emitResponse.responseTypes.SUCCESS
-        ]);
-    };
-
-    const Block_Gateway = {
-        name: name,
-        label: label,
-        content: createElement(KomojuComponent, null),
-        edit: createElement(KomojuComponent, null),
-        canMakePayment: () => true,
-        ariaLabel: settings.title || 'Payment Method',
-        supports: {
-            features: settings.supports || ['products'],
+        const label = createElement('div', {
+            style: { display: 'block', alignItems: 'center', justifyContent: 'center', width: '100%' }
         },
-    };
-    window.wc.wcBlocksRegistry.registerPaymentMethod(Block_Gateway);
-}
+            window.wp.htmlEntities.decodeEntities(settings.title || window.wp.i18n.__('NULL GATEWAY', 'test_komoju_gateway')),
+            settings.icon ?
+                createElement('img', {
+                    src: settings.icon,
+                    alt: settings.title || 'Payment Method Icon',
+                    style: { display: 'flex', alignItems: 'center', justifyContent: 'center', marginLeft: '10px' }
+                }) : null,
+            komojuFields
+        );
 
-paymentMethodData = window.wc.wcSettings.getSetting('paymentMethodData', {});
-Object.values(paymentMethodData).forEach((value) => {
-    registerPaymentMethod(value);
-});
+        const KomojuComponent = ({ activePaymentMethod, emitResponse, eventRegistration }) => {
+            const { onPaymentSetup } = eventRegistration;
+            const komojuFieldEnabledMethods = ['komoju_credit_card', 'komoju_konbini', 'komoju_bank_transfer']
+
+            useEffect(() => {
+                const komojuField = document.querySelector(`komoju-fields[payment-type='${paymentMethod.paymentType}']`);
+                komojuField.style.display = 'block';
+
+                const unsubscribe = onPaymentSetup(async () => {
+                    if (paymentMethod.id != activePaymentMethod) return;
+                    if (!komojuFieldEnabledMethods.includes(paymentMethod.id)) return;
+
+                    if (!(komojuField || typeof komojuField.submit === 'function')) {
+                        return {
+                            type: emitResponse.responseTypes.ERROR,
+                            message: 'There was an error',
+                        };
+                    }
+
+                    function submitFields(fields) {
+                        return new Promise(async (resolve, reject) => {
+                            fields.addEventListener("komoju-invalid", reject);
+                            const token = await fields.submit();
+                            fields.removeEventListener("komoju-invalid", reject);
+                            if (token) resolve(token);
+                        });
+                    }
+
+                    try {
+                        const token = await submitFields(komojuField);
+                        return {
+                            type: emitResponse.responseTypes.SUCCESS,
+                            meta: {
+                                paymentMethodData: {
+                                    komoju_payment_token: token.id
+                                },
+                            },
+                        };
+                    } catch (e) {
+                        return {
+                            type: emitResponse.responseTypes.ERROR,
+                            message: e.detail.errors[0].message,
+                        };
+                    }
+                });
+
+                return () => {
+                    komojuField.style.display = 'none';
+                    unsubscribe();
+                };
+            }, [
+                activePaymentMethod,
+                emitResponse.responseTypes.ERROR,
+                emitResponse.responseTypes.SUCCESS
+            ]);
+        };
+
+        const Block_Gateway = {
+            name: name,
+            label: label,
+            content: createElement(KomojuComponent, null),
+            edit: createElement(KomojuComponent, null),
+            canMakePayment: () => true,
+            ariaLabel: settings.title || 'Payment Method',
+            supports: {
+                features: settings.supports || ['products'],
+            },
+        };
+        window.wc.wcBlocksRegistry.registerPaymentMethod(Block_Gateway);
+    }
+
+    return {
+        init: () => {
+            const paymentMethodData = window.wc.wcSettings.getSetting('paymentMethodData', {});
+            Object.values(paymentMethodData).forEach((value) => {
+                registerPaymentMethod(value);
+            });
+        }
+    };
+})();
+
+KomojuPaymentModule.init();

--- a/index.php
+++ b/index.php
@@ -119,19 +119,16 @@ function woocommerce_komoju_init()
             return;
         }
 
-        $gateways = WC()->payment_gateways->payment_gateways();
+        add_action('woocommerce_blocks_payment_method_type_registration', function ($payment_method_registry) {
+            $gateways = WC()->payment_gateways()->payment_gateways();
 
-        if ($gateways) {
-            foreach ($gateways as $gateway) {
-                if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
-                    add_action(
-                        'woocommerce_blocks_payment_method_type_registration',
-                        function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) use ($gateway) {
-                            $payment_method_registry->register(new WC_Gateway_Komoju_Blocks($gateway));
-                        }
-                    );
+            if ($gateways) {
+                foreach ($gateways as $gateway) {
+                    if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
+                        $payment_method_registry->register(new WC_Gateway_Komoju_Blocks($gateway));
+                    }
                 }
             }
-        }
+        });
     }
 }

--- a/index.php
+++ b/index.php
@@ -119,7 +119,9 @@ function woocommerce_komoju_init()
             return;
         }
 
-        add_action('woocommerce_blocks_payment_method_type_registration', function ($payment_method_registry) {
+        add_action(
+            'woocommerce_blocks_payment_method_type_registration',
+            function ($payment_method_registry) {
             $gateways = WC()->payment_gateways()->payment_gateways();
 
             if ($gateways) {

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: KOMOJU Payments
 Plugin URI: https://github.com/komoju/komoju-woocommerce
 Description: Extends WooCommerce with KOMOJU gateway.
-Version: 3.1.0
+Version: 3.1.2
 Author: KOMOJU
 Author URI: https://komoju.com
 */

--- a/index.php
+++ b/index.php
@@ -122,15 +122,15 @@ function woocommerce_komoju_init()
         add_action(
             'woocommerce_blocks_payment_method_type_registration',
             function ($payment_method_registry) {
-            $gateways = WC()->payment_gateways()->payment_gateways();
+                $gateways = WC()->payment_gateways()->payment_gateways();
 
-            if ($gateways) {
-                foreach ($gateways as $gateway) {
-                    if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
-                        $payment_method_registry->register(new WC_Gateway_Komoju_Blocks($gateway));
+                if ($gateways) {
+                    foreach ($gateways as $gateway) {
+                        if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
+                            $payment_method_registry->register(new WC_Gateway_Komoju_Blocks($gateway));
+                        }
                     }
                 }
-            }
-        });
+            });
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,10 @@ Go back to your Wordpress instance and set the "Webhook Secret Token" value on t
 
 == Changelog ==
 
+= 3.1.2 =
+
+Fix plugin conflicts
+
 = 3.1.0 =
 Updated to use WooCommerce version 8.8.3.
 Adds a user editable description field.


### PR DESCRIPTION
# Problem

After updating 3.1.0, there was huge plugin conflicts.

# Changes

- Call the gateway in the correct timing
- Add wrapper for javascript for safety

# Source of the problem

This problem was caused by calling gateway in the wrong timing. Komoju-WooCommerece was working fine, but if other plugins which calling `payment_gateways` it was causing a conflict.

## Before

Calling `WC()->payment_gateways->payment_gateways();` in `woocommerce_blocks_loaded`

```php
    function register_komoju_payment_method_type()
    {
        if (!class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
            return;
        }

        $gateways = WC()->payment_gateways->payment_gateways();

        if ($gateways) {
...
```

## After

Calling `WC()->payment_gateways->payment_gateways();` in `woocommerce_blocks_payment_method_type_registration`

```php
add_action('woocommerce_blocks_payment_method_type_registration', function ($payment_method_registry) {
            $gateways = WC()->payment_gateways()->payment_gateways();

            if ($gateways) {
                foreach ($gateways as $gateway) {
                    if ($gateway->enabled == 'yes' && $gateway instanceof WC_Gateway_Komoju_Single_Slug) {
                        $payment_method_registry->register(new WC_Gateway_Komoju_Blocks($gateway));
                    }
```
