### PR TITLE
Update KOMOJU Plugin for WooCommerce Cart Checkout Block & HPOS

### DIFF
--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -49,6 +49,10 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
             return;
         }
 
+        if (is_wc_endpoint_url('order-received')) {
+            return;
+        }
+
         // We lazily fetch one session to be shared by all payment methods with dynamic fields.
         static $checkout_session;
         if (is_null($checkout_session)) {

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -45,7 +45,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
-        if (!is_checkout() && !$this->is_site_editor()) {
+        if (!(is_checkout() || $this->is_site_editor())) {
             return;
         }
 

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -45,11 +45,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
-        if (!is_checkout()) {
-            return;
-        }
-
-        if (is_wc_endpoint_url('order-received')) {
+        if (!is_checkout() && !$this->is_site_editor()) {
             return;
         }
 
@@ -74,5 +70,10 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
             'locale'         => $this->gateway->locale,
             'inlineFields'   => $this->gateway->has_fields,
         ];
+    }
+
+    private function is_site_editor()
+    {
+        return strpos($_SERVER['REQUEST_URI'], 'site-editor.php');
     }
 }

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -45,10 +45,6 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
-        if (!(is_checkout() || $this->is_site_editor())) {
-            return;
-        }
-
         // We lazily fetch one session to be shared by all payment methods with dynamic fields.
         static $checkout_session;
         if (is_null($checkout_session)) {
@@ -70,10 +66,5 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
             'locale'         => $this->gateway->locale,
             'inlineFields'   => $this->gateway->has_fields,
         ];
-    }
-
-    private function is_site_editor()
-    {
-        return strpos($_SERVER['REQUEST_URI'], 'site-editor.php');
     }
 }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -221,7 +221,8 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
             if (!empty($webhookEvent->payment_method_fee())) {
                 // log komoju transaction fee
-                update_post_meta($order->get_id(), 'Payment Gateway Transaction Fee', wc_clean($webhookEvent->payment_method_fee()));
+                $order->update_meta_data('Payment Gateway Transaction Fee', wc_clean($webhookEvent->payment_method_fee()));
+                $order->save();
             }
         } else {
             $this->payment_on_hold($order, sprintf(__('Payment pending: %s', 'komoju-woocommerce'), $webhookEvent->additional_information()));
@@ -343,16 +344,17 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     protected function save_komoju_meta_data($order, $webhookEvent)
     {
         if (!empty($webhookEvent->tax())) {
-            update_post_meta($order->get_id(), 'Tax', wc_clean($webhookEvent->tax()));
+            $order->update_meta_data('Tax', wc_clean($webhookEvent->tax()));
         }
         if (!empty($webhookEvent->amount())) {
-            update_post_meta($order->get_id(), 'Amount', wc_clean($webhookEvent->amount()));
+            $order->update_meta_data('Amount', wc_clean($webhookEvent->amount()));
         }
         if (!empty($webhookEvent->additional_information())) {
-            update_post_meta($order->get_id(), 'Additional info', wc_clean(print_r($webhookEvent->additional_information(), true)));
+            $order->update_meta_data('Additional info', wc_clean(print_r($webhookEvent->additional_information(), true)));
         }
         if (!empty($webhookEvent->uuid())) {
-            $order->add_meta_data('komoju_payment_id', $webhookEvent->uuid(), true);
+            $order->update_meta_data('komoju_payment_id', $webhookEvent->uuid(), true);
         }
+        $order->save();
     }
 }

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -140,6 +140,10 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
             ],
         ];
 
+        if ($this->get_order_total() == 0) {
+            return null;
+        }
+
         return $komoju_api->createSession($session_params);
     }
 

--- a/index.php
+++ b/index.php
@@ -1,12 +1,21 @@
 <?php
 /*
-Plugin Name: KOMOJU Payments
-Plugin URI: https://github.com/komoju/komoju-woocommerce
-Description: Extends WooCommerce with KOMOJU gateway.
-Version: 3.1.3
-Author: KOMOJU
-Author URI: https://komoju.com
-*/
+ * Plugin Name: KOMOJU Payments
+ * Plugin URI: https://github.com/komoju/komoju-woocommerce
+ * Description: Extends WooCommerce with KOMOJU gateway.
+ * Author: KOMOJU
+ * Author URI: https://komoju.com
+ * Version: 3.1.3
+ * WC requires at least: 6.0
+ * WC tested up to: 8.8.3
+ */
+
+add_action('before_woocommerce_init', function () {
+    if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+    }
+});
 
 add_action('plugins_loaded', 'woocommerce_komoju_init', 0);
 

--- a/index.php
+++ b/index.php
@@ -12,8 +12,8 @@
 
 add_action('before_woocommerce_init', function () {
     if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
-        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
-        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+        Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
+        Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
     }
 });
 

--- a/tests/cypress/e2e/admin.cy.js
+++ b/tests/cypress/e2e/admin.cy.js
@@ -3,13 +3,14 @@
 describe('KOMOJU for WooCommerce: Admin', () => {
   beforeEach(() => {
     cy.installWordpress();
-    cy.signinToWordpress();
-    cy.installWooCommerce();
-    cy.installKomoju();
+    cy.signinToWordpress().then(() => {
+      cy.installWooCommerce();
+      cy.installKomoju();
 
-    cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
-    cy.get('.komoju-endpoint-field').contains('Reset').click();
-    cy.contains('Save changes').click();
+      cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
+      cy.get('.komoju-endpoint-field').contains('Reset').click();
+      cy.contains('Save changes').click();
+    });
   })
 
   it('lets me add and remove specialized payment gateways', () => {
@@ -49,8 +50,8 @@ describe('KOMOJU for WooCommerce: Admin', () => {
   it('updates secret key with one-click setup', () => {
     cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
 
-    cy.get('#komoju_woocommerce_secret_key').type('{selectAll}{backspace}');
-    cy.get('#komoju_woocommerce_webhook_secret').type('{selectAll}{backspace}');
+    cy.get('#komoju_woocommerce_secret_key').clear();
+    cy.get('#komoju_woocommerce_webhook_secret').clear();
     cy.contains('Save changes').click();
 
     cy.contains('Payment methods').click();

--- a/tests/cypress/e2e/checkout.cy.js
+++ b/tests/cypress/e2e/checkout.cy.js
@@ -33,6 +33,7 @@ describe('KOMOJU for WooCommerce: Checkout', () => {
     cy.contains('How to make a payment at Family Mart', { matchCase: false, timeout: 20000 }).should('be.visible');
     cy.location('pathname').should('include', '/sessions/');
     cy.contains('Return to').click();
+    cy.wait(1000);
     cy.contains('Thank you. Your order has been received.').should('be.visible');
   })
 

--- a/tests/cypress/e2e/checkout.cy.js
+++ b/tests/cypress/e2e/checkout.cy.js
@@ -3,9 +3,10 @@
 describe('KOMOJU for WooCommerce: Checkout', () => {
   beforeEach(() => {
     cy.installWordpress();
-    cy.signinToWordpress();
-    cy.installWooCommerce();
-    cy.installKomoju();
+    cy.signinToWordpress().then(() => {
+      cy.installWooCommerce();
+      cy.installKomoju();
+    });
   })
 
   it('lets me make a payment using the specialized konbini gateway', () => {

--- a/tests/cypress/e2e/refunded-webhook.cy.js
+++ b/tests/cypress/e2e/refunded-webhook.cy.js
@@ -3,9 +3,10 @@
 describe("KOMOJU for WooCommerce: Refunded webhook", () => {
   beforeEach(() => {
     cy.installWordpress();
-    cy.signinToWordpress();
-    cy.installWooCommerce();
-    cy.installKomoju();
+    cy.signinToWordpress().then(() => {
+      cy.installWooCommerce();
+      cy.installKomoju();
+    });
   });
 
   it("sets an order as a refunded based on incoming refunded webhook", () => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -50,20 +50,16 @@ Cypress.Commands.add('installWordpress', () => {
 Cypress.Commands.add('signinToWordpress', () => {
   cy.visit('/wp-admin');
 
-  cy.window().then(win => {
-    if (!win.document.querySelector('#loginform')) {
+  cy.get('body').then(($body) => {
+    if (!$body.find('#loginform').length) {
       cy.log('Already logged in');
       return;
     }
     cy.log('Logging in');
-
-    cy.get('#user_login').clear().type('degica');
-    cy.wait(100);
-    cy.get('#user_pass').clear().type('deg1kaX7reme!');
-    cy.wait(100);
-    cy.get('#wp-submit').click();
+    cy.get('#user_login').should('be.visible').clear().type('degica');
+    cy.get('#user_pass').should('be.visible').clear().type('deg1kaX7reme!');
+    cy.get('#wp-submit').should('be.visible').click();
   });
-  cy.wait(1000);
 });
 
 Cypress.Commands.add('installWooCommerce', () => {
@@ -200,10 +196,8 @@ Cypress.Commands.add('addItemAndProceedToCheckout', () => {
     }
   });
 
-  cy.get('.wc-block-mini-cart__button').click();
-  cy.wait(100);
-  cy.contains('Go to checkout').click();
-  cy.wait(1000);
+  cy.get('.wc-block-mini-cart__button').should('be.visible').click();
+  cy.contains('Go to checkout').should('be.visible').click();
 });
 
 Cypress.Commands.add('clickPaymentTab', () => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -39,10 +39,10 @@ Cypress.Commands.add('installWordpress', () => {
     cy.contains('English (United States)').click();
     cy.get('#language-continue').click();
 
-    cy.get('#weblog_title').type('Degica Mart').type('{selectAll}Degica Mart');
-    cy.get('#user_login').type('degica');
-    cy.get('#pass1').type('{selectAll}deg1kaX7reme!');
-    cy.get('#admin_email').type('dev@degica.com');
+    cy.get('#weblog_title').clear().type('Degica Mart');
+    cy.get('#user_login').clear().type('degica');
+    cy.get('#pass1').clear().type('deg1kaX7reme!');
+    cy.get('#admin_email').clear().type('dev@degica.com');
     cy.get('#submit').click();
   });
 });
@@ -57,9 +57,9 @@ Cypress.Commands.add('signinToWordpress', () => {
     }
     cy.log('Logging in');
 
-    cy.get('#user_login').type('degica');
+    cy.get('#user_login').clear().type('degica');
     cy.wait(100);
-    cy.get('#user_pass').type('deg1kaX7reme!');
+    cy.get('#user_pass').clear().type('deg1kaX7reme!');
     cy.wait(100);
     cy.get('#wp-submit').click();
   });
@@ -112,13 +112,13 @@ Cypress.Commands.add('setupKomoju', (
 ) => {
   cy.visit('/wp-admin/admin.php?page=wc-settings&tab=komoju_settings&section=api_settings');
 
-  cy.get('#komoju_woocommerce_secret_key').type('{selectAll}').type(secretKey);
-  cy.get('#komoju_woocommerce_publishable_key').type('{selectAll}').type(publishableKey);
+  cy.get('#komoju_woocommerce_secret_key').clear().type(secretKey);
+  cy.get('#komoju_woocommerce_publishable_key').clear().type(publishableKey);
   cy.get('.komoju-endpoint-komoju_woocommerce_fields_url').then($element => {
     const $edit = $element.find('.komoju-endpoint-edit');
     if ($edit.length > 0) { return cy.wrap($edit).click(); }
   });
-  cy.get('#komoju_woocommerce_fields_url').type('{selectAll}').type('https://multipay-staging.test.komoju.com/fields.js');
+  cy.get('#komoju_woocommerce_fields_url').clear().type('https://multipay-staging.test.komoju.com/fields.js');
   cy.contains('Save changes').click();
 
   cy.contains('Payment methods').click();
@@ -150,14 +150,14 @@ Cypress.Commands.add('goToStore', () => {
 });
 
 Cypress.Commands.add('fillInAddress', () => {
-  cy.get('#billing-last_name').type('{selectAll}Johnson');
-  cy.get('#billing-first_name').type('{selectAll}Test');
+  cy.get('#billing-last_name').clear().type('Johnson');
+  cy.get('#billing-first_name').clear().type('Test');
   cy.get('#billing-country').find('#components-form-token-input-0').type('Japan').first().click();
   cy.get('#billing-state').find('input').type('Tokyo').first().click();
-  cy.get('#billing-postcode').type('{selectAll}180-0004');
-  cy.get('#billing-city').type('Musashino');
-  cy.get('#billing-address_1').type('address');
-  cy.get('#billing-phone').type('{selectAll}123123213213213');
+  cy.get('#billing-postcode').clear().type('180-0004');
+  cy.get('#billing-city').clear().type('Musashino');
+  cy.get('#billing-address_1').clear().type('address');
+  cy.get('#billing-phone').clear().type('123123213213213');
 });
 
 Cypress.Commands.add('iframe', { prevSubject: 'element' }, ($iframe) => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -57,7 +57,7 @@ Cypress.Commands.add('signinToWordpress', () => {
     }
     cy.log('Logging in');
 
-    cy.get('#user_login').type('degica').type('{selectAll}degica');
+    cy.get('#user_login').type('degica');
     cy.wait(100);
     cy.get('#user_pass').type('deg1kaX7reme!');
     cy.wait(100);
@@ -203,7 +203,7 @@ Cypress.Commands.add('addItemAndProceedToCheckout', () => {
   cy.get('.wc-block-mini-cart__button').click();
   cy.wait(100);
   cy.contains('Go to checkout').click();
-  cy.wait(100);
+  cy.wait(1000);
 });
 
 Cypress.Commands.add('clickPaymentTab', () => {

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -22,5 +22,7 @@ import './commands'
 Cypress.on('uncaught:exception', (err, runnable) => {
 	// Ignore the error if it's from a specific source
 	if (err.message.includes('@wordpress/interactivity')) return false;
+	// Ignore postMessage errors
+	if (err.message.includes('postMessage')) return false;
 	return true;
 })

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "cypress": "*"
+        "cypress": "^13.13.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -201,10 +201,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
@@ -238,14 +234,6 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -429,10 +417,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -451,9 +435,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz",
-      "integrity": "sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
+      "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
@@ -495,7 +479,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -741,10 +725,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -797,24 +777,6 @@
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-dirs": {
@@ -940,18 +902,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -1198,16 +1148,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1273,13 +1213,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -1393,19 +1326,6 @@
     "node_modules/rfdc": {
       "version": "1.3.0",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/rxjs": {
       "version": "7.5.5",
@@ -1590,13 +1510,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tough-cookie": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "cypress": "*"
+    "cypress": "^13.13.1"
   }
 }


### PR DESCRIPTION
# Description:

This PR updates the KOMOJU Payments plugin to ensure compatibility with WooCommerce's Ceckout block & High-Performance Order Storage ([HPOS](https://woocommerce.com/document/high-performance-order-storage/)) feature. The following changes have been made:

## Compatibility Declaration:
- Added code to declare compatibility with WooCommerce's 'cart_checkout_blocks' and 'custom_order_tables' features.

## Payment Method Data Handling:
- Added a check to ensure the plugin does not operate on the 'order-received' endpoint to avoid unnecessary session creation.

## Order Meta Data Handling:
- Replaced update_post_meta calls with WC_Order's update_meta_data and save methods to ensure compatibility with HPOS.
- Updated the save_komoju_meta_data function to use update_meta_data instead of update_post_meta.

## Fix timing issue in the test
- There was timing issue in cypress that it was testing without signed in correctly. So, I adjusted the process about how to sign in.

After this get merged, I will update version to 3.1.4 and will publish it.
If you have any concerns or questions please let me know!