### PR TITLE
Examine currency before recognizing as an available payment method

### DIFF
--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -370,9 +370,17 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
             foreach ($all_payment_methods as $payment_method) {
                 $slug        = $payment_method['type_slug'];
                 $pm_currency = $payment_method['currency'];
+
+                // If the payment method satisfies both of these two conditions, reject it:
+                // 1.  There is an alternative payment method with the same slug (possibly with a more preferable currency)
+                // 2.  The currency for the payment method defers from the default currency for the WooCommerce configuration
+                // That means, we accept payment methods if and only if
+                // 1.  there is no alternative payment method with the same slug, OR
+                // 2.  an alternative payment method with the same slug exists, but the currency for the payment method matches to the currency for the WooCommerce configuration and thus preferred
                 if (isset($methods_by_slug[$slug]) && $pm_currency !== $wc_currency) {
                     continue;
                 }
+
                 $methods_by_slug[$slug] = $payment_method;
             }
 

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -371,14 +371,15 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
                 $slug        = $payment_method['type_slug'];
                 $pm_currency = $payment_method['currency'];
 
-                // If the payment method satisfies both of these two conditions, reject it:
-                // 1.  There is an alternative payment method with the same slug (possibly with a more preferable currency)
-                // 2.  The currency for the payment method defers from the default currency for the WooCommerce configuration
-                // That means, we accept payment methods if and only if
-                // 1.  there is no alternative payment method with the same slug, OR
-                // 2.  an alternative payment method with the same slug exists, but the currency for the payment method matches to the currency for the WooCommerce configuration and thus preferred
-                if (isset($methods_by_slug[$slug]) && $pm_currency !== $wc_currency) {
-                    continue;
+                // If $slug is not set, register
+                if (!isset($methods_by_slug[$slug])) {
+                    $methods_by_slug[$slug] = $payment_method;
+                } else {
+                    // If $slug is already registered and
+                    // the payment currency matches the WooCommerce currency then override it
+                    if ($pm_currency === $wc_currency) {
+                        $methods_by_slug[$slug] = $payment_method;
+                    }
                 }
 
                 $methods_by_slug[$slug] = $payment_method;

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -365,10 +365,12 @@ class WC_Settings_Page_Komoju extends WC_Settings_Page
         try {
             $all_payment_methods = $api->paymentMethods();
             $methods_by_slug     = [];
+            $wc_currency         = get_woocommerce_currency();
 
             foreach ($all_payment_methods as $payment_method) {
-                $slug = $payment_method['type_slug'];
-                if (isset($methods_by_slug[$slug])) {
+                $slug        = $payment_method['type_slug'];
+                $pm_currency = $payment_method['currency'];
+                if (isset($methods_by_slug[$slug]) && $pm_currency !== $wc_currency) {
                     continue;
                 }
                 $methods_by_slug[$slug] = $payment_method;

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -49,6 +49,7 @@ Cypress.Commands.add('installWordpress', () => {
 
 Cypress.Commands.add('signinToWordpress', () => {
   cy.visit('/wp-admin');
+  cy.wait(1000);
 
   cy.get('body').then(($body) => {
     if (!$body.find('#loginform').length) {
@@ -60,6 +61,7 @@ Cypress.Commands.add('signinToWordpress', () => {
     cy.get('#user_pass').should('be.visible').clear().type('deg1kaX7reme!');
     cy.get('#wp-submit').should('be.visible').click();
   });
+  cy.wait(1000);
 });
 
 Cypress.Commands.add('installWooCommerce', () => {


### PR DESCRIPTION
By default KOMOJU merchants have multicurrency enabled, with which there can by multiple payment methods with the same `type_slug`, but with different `currency` or sets of `subtypes` (card brands).

This PR makes sure that the plugin disposes only payment methods that don't support the currency configured for the WooCommerce instance.