### PR TITLE
Cancel on expiry and duplication of payments

### DIFF
--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -121,6 +121,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
         $order = $this->get_komoju_order($webhookEvent, $this->invoice_prefix);
         if ($order) {
+            $this->save_komoju_meta_data($order, $webhookEvent);
             switch ($webhookEvent->status()) {
                 case 'captured':
                     $this->payment_status_captured($order, $webhookEvent);
@@ -213,8 +214,6 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
         } else {
             $this->validate_amount($order, $webhookEvent->grand_total() - $webhookEvent->payment_method_fee());
         }
-
-        $this->save_komoju_meta_data($order, $webhookEvent);
 
         if ('captured' === $webhookEvent->status()) {
             $this->payment_complete($order, !empty($webhookEvent->uuid()) ? wc_clean($webhookEvent->uuid()) : '', __('IPN payment captured', 'komoju-woocommerce'));

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -205,6 +205,17 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
         // Otherwise we will redirect to the KOMOJU hosted page.
         $token = sanitize_text_field($_POST['komoju_payment_token']);
 
+        // Gimmick: If there is a KOMOJU payment UUID already set for the order, try to cancel the preceding payment.
+        // Some considerations:
+        // - It will be helpful to prevent duplicated Konbini payments, which can be caused through the "order-pay" page.
+        // - If the metadata is set, the payment already exists, and it is safe to cancel the payment.
+        //   - It is also worth to note that the paths to this code guarantee that this order is payable, i.e., no payment is captured or has expired yet, and therefore it is cancellable.
+        // - If the metadata is not set, there is nothing we can do anyway.
+        $komoju_payment_id = $order->get_meta('komoju_payment_id');
+        if (!empty($komoju_payment_id)) {
+            $this->komoju_api->cancel($komoju_payment_id, []);
+        }
+
         if (!$token || $token === '') {
             return parent::process_payment($order_id, $this->payment_method['type_slug']);
         }

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -215,6 +215,9 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
             'payment_details' => $token,
         ]);
 
+        $order->set_transaction_id($session->payment_data->external_order_num);
+        $order->save();
+
         if ($result->redirect_url) {
             return [
                 'result'   => 'success',

--- a/komoju-php/komoju-php/lib/komoju/KomojuApi.php
+++ b/komoju-php/komoju-php/lib/komoju/KomojuApi.php
@@ -59,6 +59,11 @@ class KomojuApi
         return $this->post('/api/v1/payments/' . $paymentUuid . '/refund', $payload);
     }
 
+    public function cancel($paymentUuid, $payload)
+    {
+        return $this->post('/api/v1/payments/' . $paymentUuid . '/cancel', $payload);
+    }
+
     private function get($uri, $asArray = false)
     {
         $ch = curl_init($this->endpoint . $uri);


### PR DESCRIPTION
Konbini payments are unique: There's a considerable time gap between the timing that a payment is ready for capture (payment codes issued, or "authorized" in KOMOJU) and the timing of actual capture. For this purpose, the KOMOJU Payment plugin puts a WooCommerce order pending or on hold when a Konbini payment is "authorized".

During the period that orders on WooCommerce are pending or on-hold, however, WooCommerce allows shoppers to make another payment for the same order, through the page called order-pay (`/checkout/order-pay` - cf https://github.com/woocommerce/woocommerce/blob/4318dac7ecd6547a983148273fd2e278cbb18547/docs/getting-started/woocommerce-endpoints.md#L18). Due to this nature, there are multiple problematic scenarios that can happen, including:

* duplicated payments, needing refunds,
* payments can be recreated even after the Konbini payment code has expired, and time-limited offers can be "life-extended" improperly

This PR adds countermeasures against these scenarios. Particularly, it amends the codes to:

* call `set_transaction_id` much earlier, so that `expired` webhook events are handled correctly,
* it attempts to save `komoju_payment_id` (through `save_komoju_meta_data`) much earlier, for easier detection of duplicated payments, and
* it attempts to cancel a preceding payment if another payment is being created for the same order.