### PR TITLE
Skip creating checkout session when the cart is empty

### DIFF
--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -45,6 +45,10 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
+        if (!is_null(WC()->cart) && WC()->cart->is_empty()) {
+            return;
+        }
+
         // We lazily fetch one session to be shared by all payment methods with dynamic fields.
         static $checkout_session;
         if (is_null($checkout_session)) {

--- a/includes/class-wc-gateway-komoju-block.php
+++ b/includes/class-wc-gateway-komoju-block.php
@@ -45,7 +45,7 @@ final class WC_Gateway_Komoju_Blocks extends AbstractPaymentMethodType
 
     public function get_payment_method_data()
     {
-        if (!is_null(WC()->cart) && WC()->cart->is_empty()) {
+        if (!is_admin() && (is_null(WC()->cart) || WC()->cart->is_empty())) {
             return;
         }
 

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -131,8 +131,14 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
     {
         $komoju_api     = $this->komoju_api;
         $currency       = get_woocommerce_currency();
+        $orderTotal = 0;
+
+        if (WC()->cart) {
+            $orderTotal = $this->get_order_total();
+        }
+
         $session_params = [
-            'amount'         => self::to_cents($this->get_order_total(), $currency),
+            'amount'         => self::to_cents($orderTotal, $currency),
             'currency'       => $currency,
             'default_locale' => self::get_locale_or_fallback(),
             'metadata'       => [
@@ -140,7 +146,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
             ],
         ];
 
-        if ($this->get_order_total() == 0) {
+        if ($orderTotal == 0) {
             return null;
         }
 

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -131,14 +131,14 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
     {
         $komoju_api     = $this->komoju_api;
         $currency       = get_woocommerce_currency();
-        $orderTotal = 0;
+        $order_total = 0;
 
         if (WC()->cart) {
-            $orderTotal = $this->get_order_total();
+            $order_total = $this->get_order_total();
         }
 
         $session_params = [
-            'amount'         => self::to_cents($orderTotal, $currency),
+            'amount'         => self::to_cents($order_total, $currency),
             'currency'       => $currency,
             'default_locale' => self::get_locale_or_fallback(),
             'metadata'       => [
@@ -146,7 +146,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
             ],
         ];
 
-        if ($orderTotal == 0) {
+        if ($order_total == 0) {
             return null;
         }
 

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -131,7 +131,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
     {
         $komoju_api     = $this->komoju_api;
         $currency       = get_woocommerce_currency();
-        $order_total = 0;
+        $order_total    = 0;
 
         if (WC()->cart) {
             $order_total = $this->get_order_total();

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 
 /*

--- a/index.php
+++ b/index.php
@@ -1,4 +1,6 @@
 <?php
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+
 /*
  * Plugin Name: KOMOJU Payments
  * Plugin URI: https://github.com/komoju/komoju-woocommerce
@@ -130,7 +132,7 @@ function woocommerce_komoju_init()
 
         add_action(
             'woocommerce_blocks_payment_method_type_registration',
-            function ($payment_method_registry) {
+            function (PaymentMethodRegistry $payment_method_registry) {
                 $gateways = WC()->payment_gateways()->payment_gateways();
 
                 if ($gateways) {

--- a/index.php
+++ b/index.php
@@ -143,6 +143,7 @@ function woocommerce_komoju_init()
                         }
                     }
                 }
-            });
+            }
+        );
     }
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * WooCommerce Komoju Payment Gateway
  * Uninstall - removes all options from DB when user deletes the plugin via WordPress backend.


### PR DESCRIPTION
# Content

After having discussion, decided not to create checkout session when cart is null.

## Screenshots
### In admin page (No checkout block incompatible error)
<img width="1260" alt="Screenshot 2024-12-12 at 14 53 24" src="https://github.com/user-attachments/assets/df5b0bc3-689f-4114-aaa5-dc7fb22ccd64" />

### Able to add checkout block in sample page & rednering
<img width="769" alt="Screenshot 2024-12-12 at 14 53 47" src="https://github.com/user-attachments/assets/8063a3db-f2c2-444c-bdc0-ff6cf468506a" />
<img width="765" alt="Screenshot 2024-12-12 at 14 54 11" src="https://github.com/user-attachments/assets/20effaad-d73c-432f-a13c-f6264c89c38f" />
