### PR TITLE
Update both Wordpress and Woocommerce version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
       - name: Build plugin zip file
         run: ./build.bash
 
@@ -58,6 +63,9 @@ jobs:
           name: komoju-japanese-payments
       - name: Show files
         run: ls
+      - name: Modify Docker build context
+        run: |-
+          echo "RUN apt-get update && apt-get install -y build-essential libffi-dev libssl-dev" >> Dockerfile
       - name: Set up docker-compose
         run: |-
           docker compose build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   cypress-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: hoverkraft-tech/compose-action@v2.0.2
         with:
           down-flags: '--volumes'
@@ -22,7 +22,7 @@ jobs:
           npx cypress run
       - name: Upload screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots
           path: tests/cypress/screenshots/
@@ -39,7 +39,7 @@ jobs:
         run: ./build.bash
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: komoju-japanese-payments
           path: komoju-japanese-payments.zip
@@ -52,13 +52,13 @@ jobs:
       TARGET: staging
       WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'degica/komoju-e2e-tests'
           submodules: recursive
           token: ${{ secrets.BUNDLER_SSH_KEY }}
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: komoju-japanese-payments
       - name: Show files
@@ -70,5 +70,20 @@ jobs:
         run: |-
           docker compose build
           docker compose up -d
+      - name: Show container status
+        run: docker compose ps
+      - name: Wait for browser container
+        run: |
+          docker compose run --rm tester sh -c "
+            apk add --no-cache netcat-openbsd
+            echo 'Waiting for browser:4444 to be ready...'
+            for i in \$(seq 1 30); do
+              nc -z browser 4444 && echo 'Browser is ready!' && exit 0
+              echo 'Browser not ready yet. Sleeping...'
+              sleep 2
+            done
+            echo 'Timed out waiting for browser to be ready.'
+            exit 1
+          "
       - name: Run e2e tests
         run: docker compose run tester rspec spec/woocommerce

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: ls
       - name: Modify Docker build context
         run: |-
-          echo "RUN apt-get update && apt-get install -y build-essential libffi-dev libssl-dev" >> Dockerfile
+          echo "RUN apk update && apk add build-base libffi-dev openssl-dev" >> Dockerfile
       - name: Set up docker-compose
         run: |-
           docker compose build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:6.7.0
+FROM wordpress:6.7.1
 
 ARG woocommerce_version
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
    db:
      ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
        context: .
        dockerfile: Dockerfile
        args:
-         woocommerce_version: 9.4.1
+         woocommerce_version: 9.5.2
      ports:
        - "8000:80"
      restart: always

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
  * Author URI: https://komoju.com
  * Version: 3.1.5
  * WC requires at least: 6.0
- * WC tested up to: 9.4.1
+ * WC tested up to: 9.5.2
  */
 
 add_action('before_woocommerce_init', function () {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: degica
 Tags: WooCommerce,Payment Gateway,Komoju
 Requires at least: 6.0
-Tested up to: 6.7.0
+Tested up to: 6.7.1
 Stable tag: trunk
 Requires PHP: 7.2
 WC requires at least: 6.0.0
@@ -103,7 +103,7 @@ next section or contact us regarding this.
 
 = What should I do if I am using newer versions of WordPress and WooCommerce? =
 
-We recommend performing a fresh install of WordPress 6.7.0 and WooCommerce
+We recommend performing a fresh install of WordPress 6.7.1 and WooCommerce
 9.5.2 before proceeding to install this plugin. You can temporarily downgrade
 from a newer version of WordPress and WooCommerce before continuing installation.
 However, downgrading from newer versions of WordPress and WooCommerce may result in
@@ -116,11 +116,11 @@ Please contact contact@komoju.com if you have any questions about
 the installation of the module.
 
 = どのWordPress・WooCommerceのバージョンに対応していますか？=
-現時点でこのプラグインは、WordPress 6.7.0およびWooCommerce 9.5.2まで動作することが確認されています。
+現時点でこのプラグインは、WordPress 6.7.1およびWooCommerce 9.5.2まで動作することが確認されています。
 それ以降のバージョンをお使いの場合は、以下をお試し頂くか、contact@komoju.comまでご連絡ください。
 
 = 新しいバージョンのWordPressとWooCommerceを使用している場合はどうすればよいですか？ =
-このプラグインをインストールする前に、まずWordPress 6.7.0とWooCommerce 9.5.2を新規インストールすることをお勧めします。
+このプラグインをインストールする前に、まずWordPress 6.7.1とWooCommerce 9.5.2を新規インストールすることをお勧めします。
 新しいバージョンから旧バージョンへ一時的にダウングレードし、接続頂くことも可能ですが、新しいバージョンからダウングレードすると、このプラグインのインストールに問題が生じる可能性がございます。
 問題が発生した場合は、サポートチーム（contact@komoju.com）までご連絡ください。
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.7.0
 Stable tag: trunk
 Requires PHP: 7.2
 WC requires at least: 6.0.0
-WC tested up to: 9.4.1
+WC tested up to: 9.5.2
 License: MIT
 License URI: https://directory.fsf.org/wiki/License:X11
 
@@ -98,13 +98,13 @@ We currently accept the following payment methods:
 = What versions of WordPress and WooCommerce is this compatible with? =
 
 At the moment, this plugin has been tested and is known to work up to WordPress
-6.7.0 and WooCommerce 9.4.1 If you are using a later version, please check the
+6.7.1 and WooCommerce 9.5.2 If you are using a later version, please check the
 next section or contact us regarding this.
 
 = What should I do if I am using newer versions of WordPress and WooCommerce? =
 
 We recommend performing a fresh install of WordPress 6.7.0 and WooCommerce
-9.4.1 before proceeding to install this plugin. You can temporarily downgrade
+9.5.2 before proceeding to install this plugin. You can temporarily downgrade
 from a newer version of WordPress and WooCommerce before continuing installation.
 However, downgrading from newer versions of WordPress and WooCommerce may result in
 issues with installing this plugin. If you are experiencing problems, please
@@ -116,11 +116,11 @@ Please contact contact@komoju.com if you have any questions about
 the installation of the module.
 
 = どのWordPress・WooCommerceのバージョンに対応していますか？=
-現時点でこのプラグインは、WordPress 6.7.0およびWooCommerce 9.4.1まで動作することが確認されています。
+現時点でこのプラグインは、WordPress 6.7.0およびWooCommerce 9.5.2まで動作することが確認されています。
 それ以降のバージョンをお使いの場合は、以下をお試し頂くか、contact@komoju.comまでご連絡ください。
 
 = 新しいバージョンのWordPressとWooCommerceを使用している場合はどうすればよいですか？ =
-このプラグインをインストールする前に、まずWordPress 6.7.0とWooCommerce 9.4.1を新規インストールすることをお勧めします。
+このプラグインをインストールする前に、まずWordPress 6.7.0とWooCommerce 9.5.2を新規インストールすることをお勧めします。
 新しいバージョンから旧バージョンへ一時的にダウングレードし、接続頂くことも可能ですが、新しいバージョンからダウングレードすると、このプラグインのインストールに問題が生じる可能性がございます。
 問題が発生した場合は、サポートチーム（contact@komoju.com）までご連絡ください。
 
@@ -168,6 +168,12 @@ Ensure that the "Active" checkbox is also ticked and then click "Create Webhook"
 Go back to your Wordpress instance and set the "Webhook Secret Token" value on the Komoju Woocommerce plugin to be the same as the secret set for the webhook.
 
 == Changelog ==
+
+= 3.1.6 =
+
+Updated compatibility for WordPress 6.7.1.
+Upgraded support for WooCommerce 9.5.2 (previously 9.4.1).
+Fix creating checkout session when the cart is empty.
 
 = 3.1.5 =
 


### PR DESCRIPTION
# Description

Update WordPress version from 6.7.0 to 6.7.1.
Update WooCommerce from 9.4.1 to 9.5.2

# Test
- We must test before the release