### PR TITLE
Replace komoju-e2e-test with valis in CI configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,94 +1,94 @@
-  name: test
+name: test
 
-  on:
-    push:
-      branches:
-        - master
-    pull_request:
-      types: [opened, synchronize, reopened]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
-  jobs:
-    cypress-tests:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: hoverkraft-tech/compose-action@v2.0.2
-          with:
-            down-flags: '--volumes'
-        - name: Run tests
-          run: |
-            cd tests
-            npm install
-            npx cypress run
-        - name: Upload screenshots
-          if: failure()
-          uses: actions/upload-artifact@v4
-          with:
-            name: screenshots
-            path: tests/cypress/screenshots/
-    build:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+jobs:
+  cypress-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hoverkraft-tech/compose-action@v2.0.2
+        with:
+          down-flags: '--volumes'
+      - name: Run tests
+        run: |
+          cd tests
+          npm install
+          npx cypress run
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: tests/cypress/screenshots/
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Install Subversion
-          run: sudo apt-get update && sudo apt-get install -y subversion
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
 
-        - name: Build plugin zip file
-          run: ./build.bash
+      - name: Build plugin zip file
+        run: ./build.bash
 
-        - name: Upload build artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: komoju-japanese-payments
-            path: komoju-japanese-payments.zip
-            retention-days: 1
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: komoju-japanese-payments
+          path: komoju-japanese-payments.zip
+          retention-days: 1
 
-    e2e-tests:
-      needs: [build]
-      timeout-minutes: 20
-      runs-on: ubuntu-latest
-      container: mcr.microsoft.com/playwright:v1.47.2-jammy
-      steps:
-        - name: Clean Workspace Folder for self-hosted runners
-          run: rm -rf ./* ./.??* || true; ls -al
+  e2e-tests:
+    needs: [build]
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.47.2-jammy
+    steps:
+      - name: Clean Workspace Folder for self-hosted runners
+        run: rm -rf ./* ./.??* || true; ls -al
 
-        - name: Checkout degica/valis
-          uses: actions/checkout@v4
-          with:
-            repository: degica/valis
-            ref: master
-            token: ${{ secrets.BUNDLER_SSH_KEY }}
+      - name: Checkout degica/valis
+        uses: actions/checkout@v4
+        with:
+          repository: degica/valis
+          ref: master
+          token: ${{ secrets.BUNDLER_SSH_KEY }}
 
-        - name: Install dependencies
-          run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-        - name: Configure Datadog Test Optimization
-          uses: datadog/test-visibility-github-action@v2
-          with:
-            service: valis
-            languages: js
-            api_key: ${{ secrets.DD_API_KEY }}
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          service: valis
+          languages: js
+          api_key: ${{ secrets.DD_API_KEY }}
 
-        - name: Setup test environment variables
-          run: |
-            cp .env.sample .env
-            echo "TEST_URL=${{ secrets.TEST_URL }}" >> .env
-            echo "CI=true" >> .env
+      - name: Setup test environment variables
+        run: |
+          cp .env.sample .env
+          echo "TEST_URL=${{ secrets.TEST_URL }}" >> .env
+          echo "CI=true" >> .env
 
-        - name: Run Playwright tests
-          run: npx playwright test tests/tests-suites/woocommerce/woocommerce.spec.ts
-          env:
-            HOME: /root
-            WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
-            NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
+      - name: Run Playwright tests
+        run: npx playwright test tests/tests-suites/woocommerce/woocommerce.spec.ts
+        env:
+          HOME: /root
+          WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
+          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
 
-        - name: Upload Playwright report
-          uses: actions/upload-artifact@v4
-          if: ${{ always() }}
-          with:
-            name: playwright-report
-            path: playwright-report/
-            retention-days: 30
-            include-hidden-files: true
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+          include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,44 +46,50 @@ jobs:
           retention-days: 1
 
   e2e-tests:
-    runs-on: ubuntu-latest
     needs: [build]
-    env:
-      TARGET: staging
-      WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
+    if: ${{ startsWith(github.ref, 'refs/heads/master/') }}
+    timeout-minutes: 20
+    runs-on: [self-hosted, on-demand, ubuntu-22.04, xlarge]
+    container: mcr.microsoft.com/playwright:v1.47.2-jammy
     steps:
-      - uses: actions/checkout@v4
+      - name: Clean Workspace Folder for self-hosted runners
+        run: rm -rf ./* ./.??* || true; ls -al
+
+      - name: Checkout degica/valis
+        uses: actions/checkout@v4
         with:
-          repository: 'degica/komoju-e2e-tests'
-          submodules: recursive
+          repository: degica/valis
+          ref: master
           token: ${{ secrets.BUNDLER_SSH_KEY }}
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Datadog Test Optimization
+        uses: datadog/test-visibility-github-action@v2
         with:
-          name: komoju-japanese-payments
-      - name: Show files
-        run: ls
-      - name: Modify Docker build context
-        run: |-
-          echo "RUN apk update && apk add build-base libffi-dev openssl-dev" >> Dockerfile
-      - name: Set up docker-compose
-        run: |-
-          docker compose build
-          docker compose up -d
-      - name: Show container status
-        run: docker compose ps
-      - name: Wait for browser container
+          service: valis
+          languages: js
+          api_key: ${{ secrets.DD_API_KEY }}
+
+      - name: Setup test environment variables
         run: |
-          docker compose run --rm tester sh -c "
-            apk add --no-cache netcat-openbsd
-            echo 'Waiting for browser:4444 to be ready...'
-            for i in \$(seq 1 30); do
-              nc -z browser 4444 && echo 'Browser is ready!' && exit 0
-              echo 'Browser not ready yet. Sleeping...'
-              sleep 2
-            done
-            echo 'Timed out waiting for browser to be ready.'
-            exit 1
-          "
-      - name: Run e2e tests
-        run: docker compose run tester rspec spec/woocommerce
+          cp .env.sample .env
+          echo "TEST_URL=${{ needs.review_app.outputs.environment-url }}" >> .env
+          echo "CI=true" >> .env
+
+      - name: Run Playwright tests
+        run: npx playwright test --grep-invert "@visual"
+        env:
+          HOME: /root
+          WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
+          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+          include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
 
   e2e-tests:
     needs: [build]
-    if: ${{ startsWith(github.ref, 'refs/heads/master/') }}
     timeout-minutes: 20
     runs-on: [self-hosted, on-demand, ubuntu-22.04, xlarge]
     container: mcr.microsoft.com/playwright:v1.47.2-jammy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,94 +1,94 @@
-name: test
+  name: test
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, synchronize, reopened]
+  on:
+    push:
+      branches:
+        - master
+    pull_request:
+      types: [opened, synchronize, reopened]
 
-jobs:
-  cypress-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hoverkraft-tech/compose-action@v2.0.2
-        with:
-          down-flags: '--volumes'
-      - name: Run tests
-        run: |
-          cd tests
-          npm install
-          npx cypress run
-      - name: Upload screenshots
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshots
-          path: tests/cypress/screenshots/
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  jobs:
+    cypress-tests:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: hoverkraft-tech/compose-action@v2.0.2
+          with:
+            down-flags: '--volumes'
+        - name: Run tests
+          run: |
+            cd tests
+            npm install
+            npx cypress run
+        - name: Upload screenshots
+          if: failure()
+          uses: actions/upload-artifact@v4
+          with:
+            name: screenshots
+            path: tests/cypress/screenshots/
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
 
-      - name: Install Subversion
-        run: sudo apt-get update && sudo apt-get install -y subversion
+        - name: Install Subversion
+          run: sudo apt-get update && sudo apt-get install -y subversion
 
-      - name: Build plugin zip file
-        run: ./build.bash
+        - name: Build plugin zip file
+          run: ./build.bash
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: komoju-japanese-payments
-          path: komoju-japanese-payments.zip
-          retention-days: 1
+        - name: Upload build artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: komoju-japanese-payments
+            path: komoju-japanese-payments.zip
+            retention-days: 1
 
-  e2e-tests:
-    needs: [build]
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.47.2-jammy
-    steps:
-      - name: Clean Workspace Folder for self-hosted runners
-        run: rm -rf ./* ./.??* || true; ls -al
+    e2e-tests:
+      needs: [build]
+      timeout-minutes: 20
+      runs-on: ubuntu-latest
+      container: mcr.microsoft.com/playwright:v1.47.2-jammy
+      steps:
+        - name: Clean Workspace Folder for self-hosted runners
+          run: rm -rf ./* ./.??* || true; ls -al
 
-      - name: Checkout degica/valis
-        uses: actions/checkout@v4
-        with:
-          repository: degica/valis
-          ref: master
-          token: ${{ secrets.BUNDLER_SSH_KEY }}
+        - name: Checkout degica/valis
+          uses: actions/checkout@v4
+          with:
+            repository: degica/valis
+            ref: master
+            token: ${{ secrets.BUNDLER_SSH_KEY }}
 
-      - name: Install dependencies
-        run: npm ci
+        - name: Install dependencies
+          run: npm ci
 
-      - name: Configure Datadog Test Optimization
-        uses: datadog/test-visibility-github-action@v2
-        with:
-          service: valis
-          languages: js
-          api_key: ${{ secrets.DD_API_KEY }}
+        - name: Configure Datadog Test Optimization
+          uses: datadog/test-visibility-github-action@v2
+          with:
+            service: valis
+            languages: js
+            api_key: ${{ secrets.DD_API_KEY }}
 
-      - name: Setup test environment variables
-        run: |
-          cp .env.sample .env
-          echo "TEST_URL=${{ needs.review_app.outputs.environment-url }}" >> .env
-          echo "CI=true" >> .env
+        - name: Setup test environment variables
+          run: |
+            cp .env.sample .env
+            echo "TEST_URL=${{ secrets.TEST_URL }}" >> .env
+            echo "CI=true" >> .env
 
-      - name: Run Playwright tests
-        run: npx playwright test --grep-invert "@visual"
-        env:
-          HOME: /root
-          WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
-          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
+        - name: Run Playwright tests
+          run: npx playwright test tests/tests-suites/woocommerce/woocommerce.spec.ts
+          env:
+            HOME: /root
+            WAF_STAGING_TOKEN: ${{ secrets.WAF_STAGING_TOKEN }}
+            NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }}
 
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-          include-hidden-files: true
+        - name: Upload Playwright report
+          uses: actions/upload-artifact@v4
+          if: ${{ always() }}
+          with:
+            name: playwright-report
+            path: playwright-report/
+            retention-days: 30
+            include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
   e2e-tests:
     needs: [build]
     timeout-minutes: 20
-    runs-on: [self-hosted, on-demand, ubuntu-22.04, xlarge]
+    runs-on: ubuntu-latest
     container: mcr.microsoft.com/playwright:v1.47.2-jammy
     steps:
       - name: Clean Workspace Folder for self-hosted runners


### PR DESCRIPTION
# Replace `komoju-e2e-test` with `valis` in CI Configuration

## Summary
This pull request updates the CI workflow to replace the usage of the `komoju-e2e-test` repository with `valis`. Since `komoju-e2e-test` is deprecated, this change will improve maintainability and compatibility.

## Changes

1. **Updated Test Workflow**:
   - The e2e testing job now uses the `valis` repository instead of `komoju-e2e-test`.
   - Added Playwright reporting for improved debugging and test result visibility.
   - `TEST_URL` and `DD_API_KEY` have been added in the Github Secrets.

## Benefits
- Simplifies the CI configuration by using a standardized repository (`valis`).
- Leverages modern testing tools (Playwright) for improved e2e testing performance and reliability.

## Checklist
- [x] Replace `komoju-e2e-test` repository with `valis`.
- [x] Update CI workflow to use Playwright.
- [x] Configure test environment variables for seamless integration.
- [x] Ensure Playwright reporting is correctly uploaded as artifacts.

## Related Issues/Discussions
- We need to write more tests in Valis to ensure everything work as expected