### PR TITLE
Update versions in php to 3.1.6

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  *
  * @extends     WC_Payment_Gateway
  *
- * @version     3.1.5
+ * @version     3.1.6
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  *
  * @extends     WC_Settings_Page
  *
- * @version     3.1.5
+ * @version     3.1.6
  *
  * @author      Komoju
  */

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
  * Description: Extends WooCommerce with KOMOJU gateway.
  * Author: KOMOJU
  * Author URI: https://komoju.com
- * Version: 3.1.5
+ * Version: 3.1.6
  * WC requires at least: 6.0
  * WC tested up to: 9.5.2
  */


### PR DESCRIPTION
# Description

The version numbers in the PHP files were still set to 3.1.5, which is outdated. This PR updates the version numbers to 3.1.6 in preparation for the upcoming release.

## Context

These changes ensure the version numbers are consistent across all files, aligning with the upcoming release of version 3.1.6.
