### PR TITLE
Fix missing svn install in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: setup
       uses: actions/checkout@master
+    - name: Install SVN
+      run: sudo apt-get update && sudo apt-get install -y subversion
     - name: deploy plugin
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:


### PR DESCRIPTION
# Description

It appears that svn has been removed from the default Ubuntu image. Adding explicit installation of svn to resolve the deploy issue.