### PR TITLE
Move the option to use the on-hold status under API settings

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -74,7 +74,7 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
         $this->title                = $this->get_option('title');
         $this->description          = $this->get_option('description');
         $this->instructions         = $this->get_option('instructions', $this->description);
-        $this->useOnHold            = $this->get_option('useOnHold');
+        $this->useOnHold            = $this->get_option_compat('use_on_hold', 'useOnHold');
 
         // Filters
         // Actions

--- a/includes/api-settings-komoju.php
+++ b/includes/api-settings-komoju.php
@@ -48,6 +48,14 @@ return [
         'desc_tip'    => true,
     ],
     [
+        'id'          => 'komoju_woocommerce_use_on_hold',
+        'type'        => 'checkbox',
+        'title'       => __('Use on-hold status for pending payments', 'komoju-woocommerce'),
+        'desc'        => __("Use 'on-hold' status for payments that are authorized on komoju but awaiting capture. If not selected, 'payment pending' status will be used.", 'komoju-woocommerce'),
+        'default'     => WC_Gateway_Komoju::get_legacy_setting('useOnHold', 'no'),
+        'desc_tip'    => true,
+    ],
+    [
         'id'           => 'komoju_woocommerce_ipn_async',
         'type'         => 'checkbox',
         'title'        => __('Process IPNs Asynchronously', 'komoju-woocommerce'),

--- a/includes/gateway-settings-komoju.php
+++ b/includes/gateway-settings-komoju.php
@@ -35,13 +35,6 @@ return [
         'default'     => $this->default_description(),
         'desc_tip'    => true,
     ],
-    'useOnHold' => [
-        'title'       => __('Use on-hold status for pending payments', 'komoju-woocommerce'),
-        'type'        => 'checkbox',
-        'description' => __("Use 'on-hold' status for payments that are authorized on komoju but awaiting capture. If not selected, 'payment pending' status will be used.", 'komoju-woocommerce'),
-        'default'     => 'no',
-        'desc_tip'    => true,
-    ],
     'inlineFields' => [
         'title'       => __('Inline payment fields', 'komoju-woocommerce'),
         'type'        => 'checkbox',


### PR DESCRIPTION
Fixes #67

Move the option to use the on-hold status for WooCommerce orders under API settings.

Historically this option was available only for `komoju` gateway (the unified one, not for each single payment methods). This is not convenient for most merchants, because they usually don't use the gateway (actually we discourage merchants to use the gateway, in favour of per-payment-method gateways). This PR alleviates the pain by moving the option to a more obvious place, which we determined is the API settings page.