### PR TITLE
Set up GitHub Actions workflow for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Deploy Docs to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: pip install mkdocs mkdocs-material
+
+      - name: Build & Deploy
+        run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,14 +6,12 @@ repo_name: "degica/komoju-woocommerce"
 theme:
   name: material
   palette:
-    # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default 
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
 
-    # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:


### PR DESCRIPTION
## Overview

This pull request introduces a GitHub Actions workflow that automatically builds and deploys the KOMOJU WooCommerce plugin documentation using MkDocs.

## Changes Made
- **Added `.github/workflows/docs.yml`:** A new workflow file that triggers on documentation-related changes and runs `mkdocs gh-deploy`.
- **Updated `mkdocs.yml`:** Remove comments to test deployment.

## Purpose
- **Automate Documentation Deployment:** Eliminates the need for manual `mkdocs gh-deploy` commands, ensuring the documentation stays up-to-date.
- **Enhance Developer Experience:** Streamlines the process for contributors and maintainers, making it easier to manage and publish doc updates.

## Testing
1. **Workflow Execution:** Verified that a push to the main branch with changes in `docs/**` or `mkdocs.yml` triggers the action.
2. **Successful Build:** Ensured MkDocs successfully builds the site without errors.
3. **Auto Deploy:** Confirmed GitHub Pages updates the `gh-pages` branch and reflects the latest docs changes.