### PR TITLE
[CI] Add mkdocs-static-i18n plugin in deploy.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install dependencies
-        run: pip install mkdocs mkdocs-material
+        run: pip install mkdocs mkdocs-material mkdocs-static-i18n
 
       - name: Build & Deploy
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
# Description

CI is failing due to missing plugin. Add mkdocs-static-i18n plugin in deploy.yml