### PR TITLE
Do not give fields if it should not have any

### DIFF
--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -174,7 +174,7 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
     public function payment_fields()
     {
-        if (!this->has_fields) {
+        if (!$this->has_fields) {
             return;
         }
 

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -174,6 +174,10 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
     public function payment_fields()
     {
+        if (!this->has_fields) {
+            return;
+        }
+
         // We lazily fetch one session to be shared by all payment methods with dynamic fields.
         static $checkout_session;
         if (is_null($checkout_session)) {


### PR DESCRIPTION
This is a tiny tweak to make sure that we're not showing any field-related elements if Inline Fields are disabled.