### PR TITLE
Fix wrong link in English page and clean up Japanese Content

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -7,3 +7,8 @@ Give your customers a local payment experience they expect. Increase conversion 
 If you're expanding your business globally and need a payment partner with local experience, KOMOJU is right for you. Adding the payment methods your customer expects is key to success and will drastically decrease abandon rates and increase conversion and sales. Give your customers a local payment experience, in the local currency they are familiar with and with their preferred payment method.
 
 KOMOJU integrates seamlessly with your checkout and all payment options are displayed dynamically. This means you do not have to make any additional configuration after setting up our plugin.
+
+## Additional Information
+
+For more details, please visit our official website:
+[**KOMOJU Official Homepage**](https://en.komoju.com/)

--- a/docs/en/user_guide/getting_started.md
+++ b/docs/en/user_guide/getting_started.md
@@ -5,7 +5,7 @@ This guide provides a **step-by-step** explanation on how to integrate the KOMOJ
 ---
 
 ## 📌 Step 0: Register for a KOMOJU Account
-- Go to the [WooCommerce Introduction Page](https://ja.komoju.com/integrations/woocommerce-integration/) and register for a KOMOJU account.
+- Go to the [WooCommerce Introduction Page](https://en.komoju.com/integrations/woocommerce/) and register for a KOMOJU account.
   Having your account ready in advance will make the plugin setup process smoother.
 
 ---

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -41,54 +41,7 @@ KOMOJU は **チェックアウトにシームレスに統合** され、すべ�
 これにより、プラグインをセットアップした後に **追加設定を行う必要はありません**。
 よりスムーズな購入体験を提供し、売上の向上に貢献します。
 
----
-
-## 幅広いローカル決済オプション
-
-KOMOJU は、日本や韓国をはじめとした **アジア地域の多様なローカル決済方法** に対応しています。
-**PayPay**、**MerPay**、**携帯キャリア決済 (NTTドコモ, Softbank, au)** など、
-現地で人気の決済方法をサポートしているため、お客様に **馴染みのある方法** で支払いを提供できます。
-
-### 対応している決済方法の例
-
-#### **日本**
-- クレジット / デビットカード (Visa, Mastercard, American Express, JCB, Diners Club)
-- **PayPay**
-- **MerPay**
-- **携帯キャリア決済 (NTTドコモ, Softbank, au)**
-- コンビニ払い (ローソン, ファミリーマート, セブンイレブン など)
-- プリペイド電子マネー (WebMoney, BitCash, NET Cash)
-#### **韓国**
-- クレジット / デビットカード (Samsung, Lotte, Hyundai, Hana, BC, NH, Shinhan, KB)
-- **Payco**
-- **Toss**
-#### **中国**
-- Alipay
-- WeChat Pay
-- UnionPay
-#### **東南アジア**
-- GrabPay
-- OVO
-- Doku
-#### **ヨーロッパ**
-- Bancontact
-- Multibanco
-- EPS
-- Giropay
-- Przelewy24
-- BLIK
-- MyBank
-- Sofort
-
----
-
 ## 詳細情報
 
 詳しくは公式ウェブサイトをご覧ください:
-[**KOMOJU　公式ホームページ**](https://ja.komoju.com/)
-
----
-
-## 次のステップ
-
-- [**特徴と対応している決済方法**](./features.md)
+[**KOMOJU公式ホームページ**](https://ja.komoju.com/)


### PR DESCRIPTION
# Description

This pull request fix both the English and Japanese documentation:

- **Cleaned up `docs/en/index.md`** for clarity and consistency  
- **Corrected the Japanese link** in `docs/en/user_guide/getting_started.md` to point to `https://en.komoju.com/integrations/woocommerce/` instead of the Japanese URL  
- **Reduced and reorganized content** in `docs/ja/index.md` by removing detailed local payment lists (Since it is duplicated in features.md)