### PR TITLE
Add Documenting page

### DIFF
--- a/docs/en/developer_guide/documenting.md
+++ b/docs/en/developer_guide/documenting.md
@@ -1,0 +1,67 @@
+# Documentation Guide
+
+This project manages documentation using [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).  
+This guide explains how to edit existing documentation and add new pages.
+
+## What is MkDocs?
+[MkDocs](https://www.mkdocs.org/) is a static site generator that converts Markdown-based documentation into an HTML website.  
+Using the `mkdocs-material` theme, you can create a stylish and readable documentation site.
+
+## How to Edit Documentation
+Documentation is managed as Markdown (`.md`) files under `docs/en/`.  
+For example, this guide is located at `docs/en/developer_guide/documenting.md`.
+
+### 1. Editing Existing Documentation
+To edit an existing page, modify the corresponding `.md` file and create a Pull Request (PR).
+
+### 2. Adding New Documentation
+If you need to add a new page, follow these steps:
+
+1. Create an appropriate folder and `.md` file under `docs/en/`
+2. Add the new page to the `nav` section in `mkdocs.yml`
+3. Commit the changes and create a PR
+
+For example, to add a new “Payment API” guide:
+
+```plaintext
+docs/en/api/payment.md
+```
+
+Then, add the following entry to `mkdocs.yml`:
+
+```yaml
+nav:
+  - Home: index.md
+  - Developer Guide:
+      - Documenting: developer_guide/documenting.md
+  - API:
+      - Payment API: api/payment.md
+```
+
+## Previewing Changes
+To check your changes locally, run the following command:
+
+```sh
+docker compose up docs
+```
+
+Then, open `http://127.0.0.1:7777/` in your browser to preview the changes.
+
+## Deployment Process
+When changes to documentation are pushed to the `master` branch, GitHub Actions automatically deploys them.
+
+The `deploy-docs.yml` GitHub Actions workflow performs the following steps:
+
+1. Runs `mkdocs build` to generate static HTML
+2. Deploys the documentation to the `gh-pages` branch
+
+To manually trigger a deployment, run `workflow_dispatch` in GitHub Actions.
+
+## Notes
+- Keep `.md` file names and folder names in **alphanumeric characters** only.
+- If a page is not added to the `nav` section in `mkdocs.yml`, it will not appear in the documentation site.
+- To confirm a successful deployment, check the GitHub Pages URL.
+
+---
+
+Follow these steps to manage and update the documentation effectively.

--- a/docs/ja/developer_guide/documenting.md
+++ b/docs/ja/developer_guide/documenting.md
@@ -1,0 +1,68 @@
+# ドキュメントの作成方法
+
+このプロジェクトでは、[MkDocs Material](https://squidfunk.github.io/mkdocs-material/) を使用してドキュメントを管理しています。  
+ドキュメントの編集や新しいページの追加方法について説明します。
+
+## MkDocs とは？
+[MkDocs](https://www.mkdocs.org/) は、Markdown で書かれたドキュメントを HTML サイトとして生成する静的サイトジェネレーターです。  
+特に `mkdocs-material` テーマを使用することで、スタイリッシュで見やすいドキュメントサイトを作成できます。
+
+## ドキュメントの編集方法
+ドキュメントは `docs/ja/` 以下に Markdown (`.md`) ファイルとして管理されています。  
+例えば、このガイドは `docs/ja/developer_guide/documenting.md` にあります。
+
+### 1. 既存のドキュメントを編集する
+既存のページを編集する場合、対象の `.md` ファイルを修正し、Pull Request (PR) を作成してください。
+
+### 2. 新しいドキュメントを追加する
+新しいページを追加する場合、次の手順で作業してください。
+
+1. `docs/ja/` 配下に適切なフォルダと `.md` ファイルを作成
+2. `mkdocs.yml` の `nav` セクションに新しいページを追加
+3. 変更をコミットして PR を作成
+
+例えば、新しい「決済 API」ガイドを追加する場合:
+
+```plaintext
+docs/ja/api/payment.md
+```
+
+そして、`mkdocs.yml` に次のように追加します。
+
+```yaml
+nav:
+  - ホーム: index.md
+  - 開発者ガイド:
+      - ドキュメント作成: developer_guide/documenting.md
+  - API:
+      - 決済 API: api/payment.md
+```
+
+## プレビュー方法
+ローカル環境で変更を確認するには、以下のコマンドを実行してください。
+
+```sh
+docker compose up docs
+```
+
+ブラウザで `http://127.0.0.1:7777/` にアクセスすると、変更内容を確認できます。
+
+## デプロイ方法
+ドキュメントの変更が `master` ブランチにプッシュされると、GitHub Actions により自動的にデプロイされます。
+
+GitHub Actions の `deploy-docs.yml` により、以下の手順が実行されます。
+
+1. `mkdocs build` を実行し、静的 HTML を生成
+2. `gh-pages` ブランチにデプロイ
+
+手動でデプロイをトリガーする場合は、GitHub Actions の `workflow_dispatch` を実行してください。
+
+## 注意事項
+- `.md` ファイルのファイル名やフォルダ名は **英数字** で統一してください。
+- `mkdocs.yml` の `nav` にページを追加しないと、サイトに表示されません。
+- デプロイが正常に行われたか確認するには、GitHub Pages の URL にアクセスしてください。
+
+---
+
+以上の手順に従って、ドキュメントを管理・更新してください。
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,10 +36,11 @@ nav:
     - Overview: index.md
     - Benefits: komoju/benefits.md
     - Features: komoju/features.md
-  - UserGuide: user_guide/getting_started.md
-  - DeveloperGuide: 
+  - User Guide: user_guide/getting_started.md
+  - Developer Guide: 
     - Setup: developer_guide/dev_setup.md
-    - UploadPlugin: developer_guide/uploading_to_wordpress_store.md
+    - Upload Plugin: developer_guide/uploading_to_wordpress_store.md
+    - Documenting: developer_guide/documenting.md
 
 plugins:
   - i18n:
@@ -58,11 +59,12 @@ plugins:
             Overview: 概要
             Benefits: メリット
             Features: 機能
-            UserGuide: ユーザーマニュアル
-            DeveloperGuide: 開発者マニュアル
+            User Guide: ユーザーマニュアル
+            Developer Guide: 開発者マニュアル
             Guide: はじめに
             Setup: セットアップ
-            UploadPlugin: プラグインのアップロード
+            Upload Plugin: プラグインのアップロード
+            Documenting: ドキュメントの作成方法
         - locale: en
           name: English
           build: true


### PR DESCRIPTION
## Summary

This PR adds a documentation guide under `docs/en/developer_guide/documenting.md`. The guide explains how to edit existing documentation, add new pages, preview changes using Docker, and deploy updates via GitHub Actions.

## Changes
- Created `docs/en/developer_guide/documenting.md` & `docs/ja/developer_guie/documenting.md`
- Provided instructions on using MkDocs Material for documentation
- Added guidelines for modifying and adding documentation pages
- Updated previewing steps using `docker compose up docs`
- Clarified the automatic deployment process via GitHub Actions

## How to Test
1. Run `docker compose up docs`
2. Open `http://127.0.0.1:7777/` in a browser
3. Verify that the documentation renders correctly

## Additional Notes
- Ensure that new documentation pages are properly added to `mkdocs.yml`
- Deployment occurs automatically when pushing to the `master` branch

