### PR TITLE
[CE-329] Update dead documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Easily accept local payment methods around the world with [KOMOJU](https://komoj
 
 ## Documentation & Getting Started
 
-- Japanese: [KOMOJU-WooCommerce ユーザーガイド](https://tech.degica.com/komoju-woocommerce/user_guide/getting_started/)
-- English: [KOMOJU-WooCommerce Plugin: Getting Started](https://tech.degica.com/komoju-woocommerce/en/user_guide/getting_started/)
+- Japanese: [KOMOJU-WooCommerce ユーザーガイド](https://ja.doc.komoju.com/docs/getting-started-with-woocommerce)
+- English: [KOMOJU-WooCommerce Plugin: Getting Started](https://doc.komoju.com/docs/getting-started-with-woocommerce)
 
 The above guides cover:
 - Installation instructions


### PR DESCRIPTION
## Description
Update the dead documentation links in the repo README to point to readme.com.

## Test steps
Navigate [here](https://github.com/komoju/komoju-woocommerce/tree/ce-329-update-readme-documentation-links) and click on the links in the repo README, checking that:
- The link actually works
- It goes to the intended pages (Woocommerce intro)
- The locale is correct