### PR TITLE
[CE-387] Update link on WooCommerce order page to KOMOJU payment page

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -103,7 +103,12 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             return;
         }
 
-        $url = $this->komoju_api->endpoint . '/admin/payments/' . $payment_id; ?>
+        $endpoint = $this->komoju_api->endpoint;
+        if ($endpoint === 'https://komoju.com') {
+            $url = 'https://app.komoju.com/merchant/payments/' . $payment_id;
+        } else {
+            $url = $endpoint . '/merchant/payments/' . $payment_id;
+        } ?>
         <p>
             <a href="<?php echo esc_attr($url); ?>">
                 <?php echo __('View payment on KOMOJU', 'komoju-woocommerce'); ?>

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -103,12 +103,8 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
             return;
         }
 
-        $endpoint = $this->komoju_api->endpoint;
-        if ($endpoint === 'https://komoju.com') {
-            $url = 'https://app.komoju.com/merchant/payments/' . $payment_id;
-        } else {
-            $url = $endpoint . '/merchant/payments/' . $payment_id;
-        } ?>
+        $url = preg_replace('#(https?://)#', '$1app.', $this->komoju_api->endpoint)
+             . '/merchant/payments/' . $payment_id; ?>
         <p>
             <a href="<?php echo esc_attr($url); ?>">
                 <?php echo __('View payment on KOMOJU', 'komoju-woocommerce'); ?>


### PR DESCRIPTION
This PR corrects the url path shown for the `View payment on KOMOJU` link shown on the order details page on WooCommerce.

Before:
https://komoju.com/admin/payments/ba6kr1ra3elzjf96vf8aksfy5

After:
https://app.komoju.com/merchant/payments/ba6kr1ra3elzjf96vf8aksfy5

<img width="1127" height="311" alt="Screenshot 2026-05-18 at 16 19 11" src="https://github.com/user-attachments/assets/fa49be52-4d94-4699-aa36-1785d9b4358c" />

Way to test:
1. Clone repo locally
2. Run `git archive --format=zip --prefix=komoju-japanese-payments/ HEAD -o komoju-japanese-payments.zip`
3. Upload plugin archive on WooCommerce
4. Verify the link generated for an order follows the expected format 