### PR TITLE
ci: migrate workflows to self-hosted runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tag:
     name: Deploy Wordpress Plugin
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, on-demand]
     steps:
     - name: setup
       uses: actions/checkout@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, on-demand]
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   php-cs-fixer:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
+    env:
+      COMPOSER_ALLOW_SUPERUSER: 1
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cypress-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     steps:
       - uses: actions/checkout@v4
       - uses: hoverkraft-tech/compose-action@v2.0.2
@@ -27,7 +27,7 @@ jobs:
           name: screenshots
           path: tests/cypress/screenshots/
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Migration summary

Migrate GitHub-hosted runners to self-hosted runners as part of the GitHub org IP allowlist restriction (SEC-627, deadline May 29).

**Runner label mapping:**

| Old | New | Reason |
|-----|-----|--------|
| `ubuntu-latest` | `[self-hosted, on-demand]` | deploy / release — xlarge on-demand (no spot interruption) |
| `ubuntu-latest` | `[self-hosted, spot]` | regular CI — xlarge spot |

**Changed workflows:**

- `.github/workflows/deploy.yml`
  - `tag` → `on-demand`
- `.github/workflows/docs.yml`
  - `build` → `spot`
  - `deploy` → `on-demand`
- `.github/workflows/lint.yml`
  - `php-cs-fixer` → `spot`
- `.github/workflows/test.yml`
  - `cypress-tests` → `spot`
  - `build` → `spot`

If any jobs fail, please ping @harsh-gulhane

**Reference:** [GitHub IP Restriction](https://www.notion.so/GitHub-IP-Restriction-35e0fbdadd16807eb887e963924d92e0)