### PR TITLE
[CE-391] [CE-392] Error handling for when customer cancels order

### DIFF
--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -121,12 +121,13 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
 
         $order = $this->get_komoju_order($webhookEvent, $this->invoice_prefix);
         if ($order) {
-            $this->save_komoju_meta_data($order, $webhookEvent);
             switch ($webhookEvent->status()) {
                 case 'captured':
+                    $this->save_komoju_meta_data($order, $webhookEvent);
                     $this->payment_status_captured($order, $webhookEvent);
                     break;
                 case 'authorized':
+                    $this->save_komoju_meta_data($order, $webhookEvent);
                     $this->payment_status_authorized($order, $webhookEvent);
                     break;
                 case 'expired':
@@ -136,6 +137,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
                     $this->payment_status_cancelled($order, $webhookEvent);
                     break;
                 case 'refunded':
+                    $this->save_komoju_meta_data($order, $webhookEvent);
                     $this->payment_status_refunded($order, $webhookEvent);
                     break;
                 default:
@@ -202,7 +204,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_captured($order, $webhookEvent)
     {
-        if ($order->has_status('captured')) {
+        if ($order->has_status(['processing', 'completed'])) {
             WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already complete.');
             exit;
         }
@@ -290,6 +292,10 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_authorized($order, $webhookEvent)
     {
+        if ($order->has_status(['processing', 'completed', 'refunded'])) {
+            return;
+        }
+
         if ($this->useOnHold === 'yes') {
             $order->update_status('on-hold');
         } else {

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -239,7 +239,11 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
         // - If the metadata is not set, there is nothing we can do anyway.
         $komoju_payment_id = $order->get_meta('komoju_payment_id');
         if (!empty($komoju_payment_id)) {
-            $this->komoju_api->cancel($komoju_payment_id, []);
+            try {
+                $this->komoju_api->cancel($komoju_payment_id, []);
+            } catch (KomojuExceptionBadServer|KomojuExceptionBadJson $e) {
+                // Best-effort: the payment may already be cancelled or expired.
+            }
         }
 
         if (!$token || $token === '') {


### PR DESCRIPTION
When a customer cancels on the KOMOJU payment screen and returns to WooCommerce, attempting to pay again throws an error and blocks checkout.

When KOMOJU sends a `payment.cancelled` webhook, `save_komoju_meta_data` saves the cancelled payment's UUID as `komoju_payment_id` on the order. 

On the next checkout attempt, `process_payment()` tries to cancel that payment via the KOMOJU API, but it's already cancelled, returning HTTP 422. 

The `cancel()` call was not wrapped in a try-catch, so the exception propagated up and broke checkout.


  Changes:

  - **class-wc-gateway-komoju-single-slug.php**: Wrap the cancel() call in process_payment() with a try-catch. This is a best-effort operation, and if the payment is already cancelled or expired, we proceed to create a new session.
  - **class-wc-gateway-komoju-ipn-handler.php**:
    - Move save_komoju_meta_data from running unconditionally on every webhook to only running for captured, authorized, and refunded events. Cancelled/expired webhooks no longer write stale payment metadata to the order.
    - Fix payment_status_captured guard: check ['processing', 'completed'] instead of 'captured' (which WooCommerce never sets, making the old guard dead code).
    - Add guard to payment_status_authorized: skip if order is already processing, completed, or refunded, preventing a late authorized webhook from regressing
  a settled order.