### PR TITLE
Fix error when retrying payment after cancellation

### DIFF
--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -257,8 +257,6 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
                 'payment_details' => $token,
             ]);
 
-            $order->set_transaction_id($session->payment_data->external_order_num);
-            $order->save();
         } catch (Throwable $e) {
             wc_add_notice(__('A payment processing error has occurred. Please review your input and try again.', 'komoju-woocommerce'), 'error');
 

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -239,7 +239,11 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
         // - If the metadata is not set, there is nothing we can do anyway.
         $komoju_payment_id = $order->get_meta('komoju_payment_id');
         if (!empty($komoju_payment_id)) {
-            $this->komoju_api->cancel($komoju_payment_id, []);
+            try {
+                $this->komoju_api->cancel($komoju_payment_id, []);
+            } catch (KomojuExceptionBadServer|KomojuExceptionBadJson $e) {
+                // Best-effort: the payment may already be cancelled or expired.
+            }
         }
 
         if (!$token || $token === '') {

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -256,7 +256,6 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
                 'customer_email'  => $order->get_billing_email(),
                 'payment_details' => $token,
             ]);
-
         } catch (Throwable $e) {
             wc_add_notice(__('A payment processing error has occurred. Please review your input and try again.', 'komoju-woocommerce'), 'error');
 


### PR DESCRIPTION
When a customer cancels on the KOMOJU payment page and tries to pay again, the plugin attempts to cancel the previous KOMOJU payment. If that payment is already cancelled, the API returns an error that was unhandled, blocking the customer from retrying.

Wraps the cancel call in a try-catch so it doesn't break checkout on retry.