### PR TITLE
improve webhook handling and account for multiple sessions

### DIFF
--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -148,6 +148,10 @@ class WC_Gateway_Komoju extends WC_Payment_Gateway
     {
         $session = $this->create_session_for_order($order_id, $payment_type);
 
+        $order = wc_get_order($order_id);
+        $order->update_meta_data('komoju_session_id', $session->id);
+        $order->save();
+
         return [
             'result'   => 'success',
             'redirect' => $session->session_url,

--- a/class-wc-gateway-komoju.php
+++ b/class-wc-gateway-komoju.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
  *
  * @extends     WC_Payment_Gateway
  *
- * @version     3.2.5
+ * @version     3.2.6
  *
  * @author      Komoju
  */

--- a/class-wc-settings-page-komoju.php
+++ b/class-wc-settings-page-komoju.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) {
  *
  * @extends     WC_Settings_Page
  *
- * @version     3.2.5
+ * @version     3.2.6
  *
  * @author      Komoju
  */

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -202,9 +202,10 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_captured($order, $webhookEvent)
     {
-        if ($order->has_status('captured')) {
+        if ($order->has_status(['processing', 'completed'])) {
             WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already complete.');
-            exit;
+
+            return;
         }
 
         if ($webhookEvent->currency() != $order->get_currency()) {
@@ -236,10 +237,9 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     protected function payment_status_cancelled($order, $webhookEvent)
     {
         if (!$this->is_order_cancellable($order, $webhookEvent)) {
-            $transaction_id     = $order->get_transaction_id();
-            $external_order_num = $webhookEvent->external_order_num();
-            WC_Gateway_Komoju::log('Aborting, transaction_id: ' . $transaction_id . ' and external_order_num: ' . $external_order_num . ' do not match.');
-            exit;
+            WC_Gateway_Komoju::log('Aborting cancelled webhook for Order #' . $order->get_id() . ': order is not cancellable.');
+
+            return;
         }
 
         $order->update_status('cancelled', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
@@ -292,6 +292,12 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_authorized($order, $webhookEvent)
     {
+        if ($order->has_status(['processing', 'completed', 'refunded'])) {
+            WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already beyond authorized.');
+
+            return;
+        }
+
         if ($this->useOnHold === 'yes') {
             $order->update_status('on-hold');
         } else {

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -258,7 +258,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_authorized($order, $webhookEvent)
     {
-        if ($order->has_status(['processing', 'completed', 'refunded'])) {
+        if ($order->is_paid() || $order->has_status('refunded')) {
             WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already beyond authorized.');
 
             return;

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -252,23 +252,25 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function is_order_cancellable($order, $webhookEvent)
     {
+        $skippable_statuses = ['completed', 'processing', 'refunded'];
+        if ($order->has_status($skippable_statuses)) {
+            return false;
+        }
+
+        // Match webhook to the current checkout session to ignore stale cancellations
+        // from previous payment attempts (e.g. customer cancelled then retried).
+        $komoju_session_id = $order->get_meta('komoju_session_id');
+        if (!empty($komoju_session_id)) {
+            return $komoju_session_id === $webhookEvent->session_id();
+        }
+
+        // Legacy: orders created before session tracking used transaction_id
         $transaction_id = $order->get_transaction_id();
         if (empty($transaction_id)) {
             return false;
         }
-        if ($transaction_id == $webhookEvent->uuid()) {
-            return true;
-        }
 
-        // for backward compatibility
-        // Order Statuses
-        //   - processing: Payment received (paid) and stock has been reduced;
-        //   - Completed — Order fulfilled and complete – requires no further action.
-        //   - Refunded — Refunded by an admin – no further action required.
-        // @see https://woocommerce.com/document/managing-orders/
-        $skippable_statuses = ['completed', 'processing', 'refunded'];
-
-        return $transaction_id == $webhookEvent->external_order_num() && !$order->has_status($skippable_statuses);
+        return $transaction_id == $webhookEvent->uuid() || $transaction_id == $webhookEvent->external_order_num();
     }
 
     /**
@@ -351,7 +353,10 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
             $order->update_meta_data('Additional info', wc_clean(print_r($webhookEvent->additional_information(), true)));
         }
         if (!empty($webhookEvent->uuid())) {
-            $order->update_meta_data('komoju_payment_id', $webhookEvent->uuid(), true);
+            $komoju_session_id = $order->get_meta('komoju_session_id');
+            if (empty($komoju_session_id) || $komoju_session_id === $webhookEvent->session_id()) {
+                $order->update_meta_data('komoju_payment_id', $webhookEvent->uuid(), true);
+            }
         }
         $order->save();
     }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -202,7 +202,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_captured($order, $webhookEvent)
     {
-        if ($order->has_status(['processing', 'completed'])) {
+        if ($order->is_paid()) {
             WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already complete.');
 
             return;
@@ -238,6 +238,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     {
         if (!$this->is_order_cancellable($order, $webhookEvent)) {
             WC_Gateway_Komoju::log('Aborting cancelled webhook for Order #' . $order->get_id() . ': order is not cancellable.');
+            $order->add_order_note(__('KOMOJU cancellation received but ignored — does not match current payment session.', 'komoju-woocommerce'));
 
             return;
         }
@@ -294,6 +295,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     {
         if ($order->has_status(['processing', 'completed', 'refunded'])) {
             WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already beyond authorized.');
+            $order->add_order_note(__('KOMOJU authorization received but ignored — payment already captured.', 'komoju-woocommerce'));
 
             return;
         }

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -236,41 +236,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_cancelled($order, $webhookEvent)
     {
-        if (!$this->is_order_cancellable($order, $webhookEvent)) {
-            WC_Gateway_Komoju::log('Aborting cancelled webhook for Order #' . $order->get_id() . ': order is not cancellable.');
-
-            return;
-        }
-
-        $order->update_status('cancelled', sprintf(__('Payment %s via IPN.', 'komoju-woocommerce'), wc_clean($webhookEvent->status())));
-    }
-
-    /**
-     * @param WC_Order $order
-     *
-     * @return bool return true if the order is cancellable
-     */
-    protected function is_order_cancellable($order, $webhookEvent)
-    {
-        $skippable_statuses = ['completed', 'processing', 'refunded'];
-        if ($order->has_status($skippable_statuses)) {
-            return false;
-        }
-
-        // Match webhook to the current checkout session to ignore stale cancellations
-        // from previous payment attempts (e.g. customer cancelled then retried).
-        $komoju_session_id = $order->get_meta('komoju_session_id');
-        if (!empty($komoju_session_id)) {
-            return $komoju_session_id === $webhookEvent->session_id();
-        }
-
-        // Legacy: orders created before session tracking used transaction_id
-        $transaction_id = $order->get_transaction_id();
-        if (empty($transaction_id)) {
-            return false;
-        }
-
-        return $transaction_id == $webhookEvent->uuid() || $transaction_id == $webhookEvent->external_order_num();
+        WC_Gateway_Komoju::log('Payment cancelled for Order #' . $order->get_id() . '. Order status not updated — customer may retry.');
     }
 
     /**
@@ -281,7 +247,7 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
      */
     protected function payment_status_expired($order, $webhookEvent)
     {
-        $this->payment_status_cancelled($order, $webhookEvent);
+        WC_Gateway_Komoju::log('Payment expired for Order #' . $order->get_id() . '. Order status not updated — customer may retry.');
     }
 
     /**

--- a/includes/class-wc-gateway-komoju-ipn-handler.php
+++ b/includes/class-wc-gateway-komoju-ipn-handler.php
@@ -238,7 +238,6 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     {
         if (!$this->is_order_cancellable($order, $webhookEvent)) {
             WC_Gateway_Komoju::log('Aborting cancelled webhook for Order #' . $order->get_id() . ': order is not cancellable.');
-            $order->add_order_note(__('KOMOJU cancellation received but ignored — does not match current payment session.', 'komoju-woocommerce'));
 
             return;
         }
@@ -295,7 +294,6 @@ class WC_Gateway_Komoju_IPN_Handler extends WC_Gateway_Komoju_Response
     {
         if ($order->has_status(['processing', 'completed', 'refunded'])) {
             WC_Gateway_Komoju::log('Aborting, Order #' . $order->get_id() . ' is already beyond authorized.');
-            $order->add_order_note(__('KOMOJU authorization received but ignored — payment already captured.', 'komoju-woocommerce'));
 
             return;
         }

--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -252,7 +252,11 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
         try {
             $session = $this->create_session_for_order($order_id, $payment_type);
-            $result  = $this->komoju_api->paySession($session->id, [
+
+            $order->update_meta_data('komoju_session_id', $session->id);
+            $order->save();
+
+            $result = $this->komoju_api->paySession($session->id, [
                 'customer_email'  => $order->get_billing_email(),
                 'payment_details' => $token,
             ]);

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
  * Author URI: https://komoju.com
  * Version: 3.2.6
  * WC requires at least: 6.0
- * WC tested up to: 9.8.5
+ * WC tested up to: 10.7.0
  */
 
 add_action('before_woocommerce_init', function () {

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
  * Description: Extends WooCommerce with KOMOJU gateway.
  * Author: KOMOJU
  * Author URI: https://komoju.com
- * Version: 3.2.5
+ * Version: 3.2.6
  * WC requires at least: 6.0
  * WC tested up to: 9.8.5
  */

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === KOMOJU Payments ===
-Contributors: degica
+Contributors: KOMOJU
 Tags: WooCommerce,Payment Gateway,Komoju
 Requires at least: 6.0
-Tested up to: 6.7.2
+Tested up to: 6.9.4
 Stable tag: trunk
 Requires PHP: 7.2
 WC requires at least: 6.0.0
-WC tested up to: 9.7.1
+WC tested up to: 10.7.0
 License: MIT
 License URI: https://directory.fsf.org/wiki/License:X11
 
@@ -177,6 +177,14 @@ Go back to your Wordpress instance and set the "Webhook Secret Token" value on t
 
 == Changelog ==
 
+= 3.2.6 =
+
+Updated link to KOMOJU payment page on order dashboard to use the "/merchant" path
+Fixed bug where a customer who returned to the checkout page could not create another payment for the same order
+Added "komoju_session_id" as metadata on the order page
+Updated compatibility for WordPress 6.9.4
+Upgraded support for WooCommerce 10.7.0
+
 = 3.2.5 =
 
 Add cURL timeouts and graceful error handling to prevent checkout errors
@@ -208,7 +216,7 @@ Update readme.txt
 = 3.1.8 =
 
 Added Quick Start Guide Link
-Updated compatibility for WordPress 6.7.2.
+Updated compatibility for WordPress 6.7.2
 Upgraded support for WooCommerce 9.7.1
 Fix: Hide field-related elements when inline fields are disabled
 


### PR DESCRIPTION
Fixes an issue where a customer who cancels on the KOMOJU payment page and retries checkout encounters an error because stale webhooks from the previous attempt interfere with the new payment.
 
 Additionally guards against cases where webhook payloads are received out of order.

Changes:

   - Store `komoju_session_id` on the order at checkout so each payment attempt can be identified
   - Ignore stale cancelled/expired webhooks that don't match the current payment session
   - Add a status guard to `payment_status_authorized` so a resent `authorized` or `canceled` webhook can't downgrade an already-captured order
   - Fix the `payment_status_captured` idempotency check as it was guarding against a `captured` WooCommerce status that doesn't exist (should be `processing`/`completed`)
   - Prevent stale webhooks from overwriting `komoju_payment_id` order metadata
   - Replace `exit` with `return` in webhook handlers so WordPress can send proper HTTP responses

How to test:
1. Clone repo and run `git archive --format=zip --prefix=komoju-japanese-payments/ HEAD -o komoju-japanese-payments.zip`
2. Upload zip file on the WooCommerce dashboard
3. Create a WooCommerce order in test mode, but do not compete the payment (can be in authorized or canceled status)
4. Return to the checkout page, and create another payment
5. Capture the payment
6. Verify that only one order was created for the above flow on WooCommerce.