### PR TITLE
Fix Apple Pay's komoju-fields issue

### DIFF
--- a/includes/class-wc-gateway-komoju-single-slug.php
+++ b/includes/class-wc-gateway-komoju-single-slug.php
@@ -178,6 +178,14 @@ class WC_Gateway_Komoju_Single_Slug extends WC_Gateway_Komoju
 
     public function should_use_inline_fields($slug)
     {
+        // Apple Pay must never use inline Hosted Fields. Hosted Fields would require
+        // registering each merchant's domain with Apple (which we don't do), and even
+        // when it loads it conflicts with WooCommerce's own "Pay" button (two competing
+        // pay actions). Apple Pay must always go through the full KOMOJU Hosted Page
+        // redirect flow instead, like other methods that don't support Hosted Fields.
+        if ($slug === 'apple_pay') {
+            return false;
+        }
         // Merchants can disable inline payment fields via gateway settings.
         if ($this->get_option('inlineFields') !== 'yes') {
             return false;


### PR DESCRIPTION
Apple Pay should be used through sessions (hosted page) and not through komoju-fields as it won't work (conflicting logic + no validated domains).

Trying to use it through komoju-fields won't work and you end up with a bunch of JS errors for certain paths such as order-pay.

This PR filters the payment slug out of the inline fields logic to avoid using komoju-fields with `apple_pay` slug. The change should be scoped to this slug alone.
I also noticed some rendering problems (CSS) with the cancel scenario (when you reach the hosted page and click "back to merchant" without paying). These issues to not appear in the main checkout because it uses a different path (order-pay vs checkout path). The fix is clear from the order-pay path as trying to pay again, from this order-pay page, will go to hosted page but on `master` it uses komoju-field and simply won't work (you get a JS error and it leads nowhere).

cancel (order-pay path) `master` vs this branch

`master`
<img width="1026" height="822" alt="Screenshot 2026-06-18 at 15 22 01" src="https://github.com/user-attachments/assets/e3a495b0-8374-4eaa-bb66-1717368e4871" />

<img width="1693" height="869" alt="Screenshot 2026-06-18 at 15 27 12" src="https://github.com/user-attachments/assets/ef932c4e-37ba-48b0-acd4-42dbefbf6015" />



branch: (you can notice that there are no credit card icons because it is not komoju-fields)
<img width="1047" height="766" alt="Screenshot 2026-06-18 at 15 22 57" src="https://github.com/user-attachments/assets/f0049ffd-ce16-4386-a341-a37ab3c08bbc" />

clicking it will correctly lead you to hosted page
<img width="1517" height="790" alt="Screenshot 2026-06-18 at 15 46 31" src="https://github.com/user-attachments/assets/c60efa41-1cd4-42fa-b690-1795cba2ae5b" />

